### PR TITLE
scripts: fix install-all command

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "install-all": "npm install && cd frontend && npm install",
+    "install-all": "npm install && cd frontend && npm install --legacy-peer-deps",
     "build-ui": "cd frontend && npm run build"
   },
   "dependencies": {


### PR DESCRIPTION
Currently, `npm install` for frontend requires to use `--legacy-peer-deps` to avoid failing during dependencies installation. Add the flag to command used in development docs to make it consistent.

Dockerfile for reference: https://github.com/TheDuffman85/crowdsec-web-ui/blob/89c023291359b6e19b9e72e16a097b62e5094abc/Dockerfile#L13-L14