### PR TITLE
api: enable compression by default

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const axios = require('axios');
 const cors = require('cors');
 const path = require('path');
 const fs = require('fs');
+const compression = require('compression');
 
 // ============================================================================
 // CONSOLE LOGGING OVERRIDES (Add Timestamps)
@@ -971,6 +972,7 @@ async function checkForUpdates() {
 app.use(cors());
 app.use(express.json());
 app.use(activityTracker); // Apply to all routes
+app.use(compression());
 
 /**
  * Middleware to ensure we have a token or try to get one

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.13.2",
         "better-sqlite3": "^12.5.0",
+        "compression": "^1.8.1",
         "cors": "^2.8.5",
         "express": "^4.17.1"
       },
@@ -292,6 +293,45 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/concat-map": {
@@ -1176,6 +1216,15 @@
       "dependencies": {
         "ee-first": "1.1.1"
       },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.13.2",
     "better-sqlite3": "^12.5.0",
+    "compression": "^1.8.1",
     "cors": "^2.8.5",
     "express": "^4.17.1"
   },


### PR DESCRIPTION
On larger installations listing of decisions and alerts might require megabytes of data to be transferred. Using compression by default allows reducing amount of data transferred significantly - e.g. 3.58MB to 191.87KB. This speeds up page loads significantly.

Attached screenshots of the results for an installation with 4k alerts and 21k decisions:


<details>

<summary>Before</summary>

<img width="2151" height="247" alt="before" src="https://github.com/user-attachments/assets/1d84d922-c984-45ac-8cd2-ccb9834c9416" />
</details>


<details>

<summary>After</summary>
<img width="2146" height="237" alt="after" src="https://github.com/user-attachments/assets/c9424d57-b14a-4f11-974d-f50b94466f2f" />


</details>
