### PR TITLE
fix(map): resolve China not appearing on world map

### DIFF
--- a/frontend/src/components/WorldMapCard.jsx
+++ b/frontend/src/components/WorldMapCard.jsx
@@ -233,12 +233,13 @@ export function WorldMapCard({ data, onCountrySelect, selectedCountry }) {
                         .filter(f => f.properties.ISO_A2 !== 'AQ' && f.properties.NAME !== 'Antarctica')
                         .map(feature => {
                             const properties = feature.properties || {};
+                            // POSTAL removed - it can conflict with ISO codes
+                            // (e.g., N. Cyprus has POSTAL=CN which would hide China)
                             const candidates = [
                                 properties.ISO_A2,
                                 properties.iso_a2,
                                 properties.ISO_A2_EH,
-                                properties.WB_A2,
-                                properties.POSTAL
+                                properties.WB_A2
                             ];
 
                             let validCode = null;


### PR DESCRIPTION
N. Cyprus had POSTAL=CN which conflicted with China's ISO_A2=CN. When code fell back to POSTAL codes for countries with invalid ISO_A2, N. Cyprus got assigned 'CN' first, causing China to be filtered as duplicate.

Removed POSTAL from candidate codes list since postal codes can conflict with ISO country codes.