### PR TITLE
fix: top scenarios column overflow

### DIFF
--- a/frontend/src/components/ScenarioName.jsx
+++ b/frontend/src/components/ScenarioName.jsx
@@ -17,10 +17,10 @@ export function ScenarioName({ name, showLink = false, className = "" }) {
     const hubUrl = showLink ? getHubUrl(name) : null;
 
     return (
-        <div className={`flex flex-col items-start leading-tight ${className}`}>
+        <div className={`flex flex-col items-start leading-tight min-w-0 ${className}`}>
             {namespace && <span className="text-xs text-gray-500 font-normal leading-none">{namespace}</span>}
-            <div className="flex items-center gap-1">
-                <span className="font-medium truncate text-gray-900 dark:text-gray-200 text-sm leading-tight">{shortName}</span>
+            <div className="flex items-center gap-1 min-w-0 w-full">
+                <span className="font-medium truncate text-gray-900 dark:text-gray-200 text-sm leading-tight min-w-0">{shortName}</span>
                 {showLink && hubUrl && (
                     <a
                         href={hubUrl}

--- a/frontend/src/components/StatCard.jsx
+++ b/frontend/src/components/StatCard.jsx
@@ -59,7 +59,7 @@ export function StatCard({
                                         : 'border-transparent hover:bg-gray-50 dark:hover:bg-gray-700/50'
                                         }`}
                                 >
-                                    <div className="flex items-center gap-2 min-w-0 flex-1">
+                                    <div className="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
                                         <span className={`flex-shrink-0 w-6 h-6 flex items-center justify-center rounded-full text-xs font-semibold ${isSelected
                                             ? 'bg-primary-600 text-white'
                                             : 'bg-primary-100 dark:bg-primary-900/30 text-primary-700 dark:text-primary-300'
@@ -69,20 +69,22 @@ export function StatCard({
                                         {item.countryCode && (
                                             <span className={`fi fi-${item.countryCode.toLowerCase()} flex-shrink-0 rounded-sm`} />
                                         )}
-                                        {renderLabel ? (
-                                            renderLabel(item)
-                                        ) : (
-                                            <span className={`text-sm truncate font-medium ${isSelected ? 'text-primary-900 dark:text-white' : 'text-gray-900 dark:text-gray-100'}`} title={item.label}>
-                                                {item.label}
-                                            </span>
-                                        )}
+                                        <div className="min-w-0 flex-1">
+                                            {renderLabel ? (
+                                                renderLabel(item)
+                                            ) : (
+                                                <span className={`text-sm truncate font-medium ${isSelected ? 'text-primary-900 dark:text-white' : 'text-gray-900 dark:text-gray-100'}`} title={item.label}>
+                                                    {item.label}
+                                                </span>
+                                            )}
+                                        </div>
                                         {hubUrl && !renderLabel && (
                                             <a
                                                 href={hubUrl}
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 onClick={(e) => e.stopPropagation()}
-                                                className="ml-1 p-1 text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors"
+                                                className="ml-1 p-1 text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 transition-colors flex-shrink-0"
                                                 title="View on CrowdSec Hub"
                                             >
                                                 <ExternalLink size={12} />


### PR DESCRIPTION
This PR fixes an overflow issue on the Top Scenarios column of the dashboard. Issue #69 

Before:
<img width="170" height="625" alt="image" src="https://github.com/user-attachments/assets/b9b192b6-4cbf-4b22-b2a2-dabe0a7a0ed0" />


Now:
<img width="174" height="622" alt="image" src="https://github.com/user-attachments/assets/3d49cf5d-81c5-41a3-9104-8c54fa334480" />
