### PR TITLE
fix: prevent update badge from persisting after container update (#119)

### DIFF
--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -17,7 +17,7 @@ export function Sidebar({ isOpen, onClose, onToggle, theme, toggleTheme }) {
     useEffect(() => {
         const checkUpdates = async () => {
             try {
-                const response = await fetch(apiUrl('/api/update-check'));
+                const response = await fetch(apiUrl('/api/update-check'), { cache: 'no-store' });
                 if (response.ok) {
                     setUpdateStatus(await response.json());
                 }


### PR DESCRIPTION
Add Cache-Control headers to /api/update-check endpoint and no-store fetch option on the client to prevent browsers and reverse proxies from serving stale cached responses. Normalize version strings for robust comparison on main branch. Use GHCR registry tags for exact dev build number matching with workflow API fallback.