### PR TITLE
fix: retry login on startup instead of aborting if LAPI is not ready

### DIFF
--- a/index.js
+++ b/index.js
@@ -1671,11 +1671,14 @@ if (BASE_PATH) {
   // First, ensure we're logged in
   if (hasCredentials()) {
     console.log('Ensuring authentication before cache initialization...');
-    const loginSuccess = await loginToLAPI();
 
-    if (!loginSuccess) {
-      console.error('Failed to login - cache initialization aborted');
-      return;
+    let loginSuccess = false;
+    while (!loginSuccess) {
+      loginSuccess = await loginToLAPI();
+      if (!loginSuccess) {
+        console.error('Failed to login - retrying in 30s...');
+        await new Promise(r => setTimeout(r, 30000));
+      }
     }
 
     console.log('Starting cache initialization...');


### PR DESCRIPTION
## Problem

If CrowdSec LAPI is not yet ready when the UI container starts (common with Docker/Podman container startup ordering), the initial login attempt fails and the startup IIFE returns early. This leaves the background refresh scheduler **permanently unstarted** for the lifetime of the container.

The cache may still get lazily initialized later via API route handlers (triggered by browser requests), but since those handlers don't call `startRefreshScheduler()`, the data is **never refreshed** — the UI silently shows stale data indefinitely.

This is easy to miss because:
- The container stays running (no crash)
- `/api/health` returns `{"status":"ok"}`
- The cache does initialize (via lazy route handler init), so the UI appears to work initially

The only symptoms are no scheduler log output after startup and increasingly stale data.

## Fix

Retry the login every 30 seconds instead of giving up, so that once LAPI becomes available the normal startup path completes: cache initializes and the scheduler starts.

## Testing

Reproduced and verified the fix by stopping the CrowdSec container before starting the UI:

**Before:** `Failed to login - cache initialization aborted` — scheduler never starts, data goes stale indefinitely

**After:** `Failed to login - retrying in 30s...` — once CrowdSec comes up, cache initializes and scheduler starts normally:
```
Starting smart scheduler (active: 30s, idle: 5m)...
Background refresh triggered (ACTIVE)...
Fetching delta updates (since: 41s)...
Delta update complete: 166 alerts, 9 active decision alerts refreshed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)