### PR TITLE
feat: display machine_id in alerts list and detail view

### DIFF
--- a/client/src/pages/Alerts.tsx
+++ b/client/src/pages/Alerts.tsx
@@ -505,6 +505,7 @@ export function Alerts() {
                                     />
                                 </th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Time</th>
+                                <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Machine</th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Scenario</th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">Country</th>
                                 <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wider">AS</th>
@@ -515,9 +516,9 @@ export function Alerts() {
                         </thead>
                         <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                             {loading ? (
-                                <tr><td colSpan={8} className="px-6 py-4 text-center text-sm text-gray-500">Loading alerts...</td></tr>
+                                <tr><td colSpan={9} className="px-6 py-4 text-center text-sm text-gray-500">Loading alerts...</td></tr>
                             ) : visibleAlerts.length === 0 ? (
-                                <tr><td colSpan={8} className="px-6 py-4 text-center text-sm text-gray-500">No alerts found</td></tr>
+                                <tr><td colSpan={9} className="px-6 py-4 text-center text-sm text-gray-500">No alerts found</td></tr>
                             ) : (
                                 visibleAlerts.map((alert, index) => {
                                     const isLastElement = index === visibleAlerts.length - 1;
@@ -541,6 +542,9 @@ export function Alerts() {
                                             </td>
                                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-900 dark:text-gray-100">
                                                 <TimeDisplay timestamp={alert.created_at} />
+                                            </td>
+                                            <td className="px-6 py-4 text-sm text-gray-500 dark:text-gray-400 max-w-[120px] truncate" title={alert.machine_alias || alert.machine_id || undefined}>
+                                                {alert.machine_alias || alert.machine_id || "-"}
                                             </td>
                                             <td className="px-6 py-4 text-sm text-gray-900 dark:text-gray-100 max-w-[200px]" title={alert.scenario}>
                                                 <ScenarioName
@@ -663,7 +667,18 @@ export function Alerts() {
                         </p>
 
                         {/* Summary Cards */}
-                        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                        <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                            <div className="p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-100 dark:border-gray-700/50">
+                                <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Machine</h4>
+                                <div className="text-lg text-gray-900 dark:text-gray-100 font-medium">
+                                    {selectedAlert.machine_alias || selectedAlert.machine_id || "-"}
+                                </div>
+                                {selectedAlert.machine_alias && selectedAlert.machine_id && selectedAlert.machine_alias !== selectedAlert.machine_id && (
+                                    <div className="text-xs text-gray-400 font-mono mt-1">
+                                        {selectedAlert.machine_id}
+                                    </div>
+                                )}
+                            </div>
                             <div className="p-4 bg-gray-50 dark:bg-gray-900/50 rounded-lg border border-gray-100 dark:border-gray-700/50">
                                 <h4 className="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-2">Scenario</h4>
                                 <div className="font-medium text-gray-900 dark:text-gray-100 break-words">


### PR DESCRIPTION
## Summary

In multi-server deployments with a central LAPI, knowing which machine generated each alert is essential for operational triage. The `machine_id` (and `machine_alias`) fields are already present in the API response and type definitions (`SlimAlert`, `AlertRecord`) but were not displayed anywhere in the UI.

This PR adds:
- **Alerts list table**: new "Machine" column between Time and Scenario
- **Alert detail modal**: new "Machine" summary card alongside Scenario, Location, and IP/Range (grid changed from 3 to 4 columns)

## Details

- Displays `machine_alias` when available, falls back to `machine_id`, shows "-" if neither is set
- In the detail modal, when both alias and id exist and differ, the id is shown as a subtitle in monospace
- `colSpan` updated from 8 to 9 for loading/empty table states
- No backend changes needed — data was already flowing through correctly

## Screenshots

Tested on a production deployment with 20 agents reporting to a central LAPI.

<img width="1153" height="274" alt="CnP_03042026_234528" src="https://github.com/user-attachments/assets/2c4acf05-c38a-43b3-97ee-184e937f0a48" />

## Test plan

- [x] Verify "Machine" column appears in alerts list with correct machine names
- [x] Verify "Machine" card appears in alert detail modal
- [x] Verify fallback to "-" when machine_id is not present
- [x] Verify responsive layout (4-column grid on desktop, stacked on mobile)
- [x] Verify dark/light mode rendering