### PR TITLE
fix: preserve notification settings across restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -695,7 +695,7 @@ A Helm chart for deploying `crowdsec-web-ui` on Kubernetes is available (maintai
 
 ## Persistence & Alert History
 
-All data is stored in a single SQLite database at `/app/data/crowdsec.db`. To persist data across container restarts, mount the `/app/data` directory.
+All data is stored in SQLite under `/app/data`. To persist data across container restarts, mount the `/app/data` directory rather than only the `crowdsec.db` file, because SQLite also uses `crowdsec.db-wal` and `crowdsec.db-shm` sidecar files.
 
 **Docker Run:**
 Add `-v $(pwd)/data:/app/data` to your command.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     env_file:
       - .env
     volumes:
-      - ./crowdsec.db:/app/data/crowdsec.db
+      - ./data:/app/data
     healthcheck:
       test: ["CMD", "node", "-e", "fetch('http://localhost:3000/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"]
       interval: 30s

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -15,16 +15,9 @@ if [ -d "/app/data" ]; then
         exit 1
     fi
 
-    # Clean up stale SQLite WAL/SHM files to prevent locking/compatibility issues
-    # when switching between local/dev runtimes or container rebuilds.
-    if [ -f "/app/data/crowdsec.db-wal" ]; then
-        echo "Removing stale WAL file..."
-        rm -f /app/data/crowdsec.db-wal
-    fi
-    if [ -f "/app/data/crowdsec.db-shm" ]; then
-        echo "Removing stale SHM file..."
-        rm -f /app/data/crowdsec.db-shm
-    fi
+    # Keep SQLite WAL/SHM files intact. They can contain committed writes that
+    # have not been checkpointed into crowdsec.db yet, especially after a
+    # container restart.
 fi
 
 # Switch to 'node' user and execute the command (if root)

--- a/server/database.test.ts
+++ b/server/database.test.ts
@@ -1,6 +1,6 @@
 import Database from 'better-sqlite3';
 import { afterEach, describe, expect, test } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from 'fs';
 import path from 'path';
 import { tmpdir } from 'os';
 import { CrowdsecDatabase } from './database';
@@ -378,6 +378,44 @@ describe('CrowdsecDatabase', () => {
     expect(db.listNotificationChannels()).toHaveLength(0);
 
     db.close();
+  });
+
+  test('checkpoints WAL data on close so settings survive container recreation', () => {
+    const dbPath = createTestDatabasePath();
+    const db = new CrowdsecDatabase({ dbPath });
+
+    db.upsertNotificationChannel({
+      $id: 'channel-persisted',
+      $created_at: '2026-05-14T15:00:00.000Z',
+      $updated_at: '2026-05-14T15:00:00.000Z',
+      $name: 'Persisted ntfy',
+      $type: 'ntfy',
+      $enabled: 1,
+      $config_json: JSON.stringify({ topic: 'crowdsec' }),
+    });
+
+    db.close();
+
+    const walPath = `${dbPath}-wal`;
+    if (existsSync(walPath)) {
+      expect(statSync(walPath).size).toBe(0);
+    }
+
+    const reopened = new CrowdsecDatabase({ dbPath });
+    expect(reopened.listNotificationChannels()).toEqual([
+      expect.objectContaining({
+        id: 'channel-persisted',
+        name: 'Persisted ntfy',
+      }),
+    ]);
+    reopened.close();
+  });
+
+  test('docker entrypoint preserves SQLite WAL files for restart recovery', () => {
+    const entrypoint = readFileSync(path.resolve(process.cwd(), 'docker-entrypoint.sh'), 'utf8');
+
+    expect(entrypoint).not.toContain('rm -f /app/data/crowdsec.db-wal');
+    expect(entrypoint).not.toContain('rm -f /app/data/crowdsec.db-shm');
   });
 
   test('migrates legacy notification rules, notifications, and seeds incidents from history', () => {

--- a/server/database.ts
+++ b/server/database.ts
@@ -304,7 +304,11 @@ export class CrowdsecDatabase {
   }
 
   close(): void {
-    this.db.close();
+    try {
+      this.db.exec('PRAGMA wal_checkpoint(TRUNCATE)');
+    } finally {
+      this.db.close();
+    }
   }
 
   clearSyncData(): void {

--- a/server/index.ts
+++ b/server/index.ts
@@ -33,7 +33,9 @@ if (controller.config.basePath) {
 function shutdown(signal: NodeJS.Signals): void {
   console.log(`Received ${signal}, shutting down...`);
   controller.stopBackgroundTasks();
-  server.close();
+  server.close(() => {
+    controller.database.close();
+  });
 }
 
 process.once('SIGINT', () => shutdown('SIGINT'));


### PR DESCRIPTION
Keep SQLite WAL files intact on startup and checkpoint the database during graceful shutdown so saved notification channels and rules survive container recreation.

Fixes #265