### PR TITLE
feat: report CrowdSec machine heartbeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ Choose exactly one auth mode: password auth or mTLS auth.
 | `CROWDSEC_IDLE_THRESHOLD` | `2m` | Inactivity period before the app switches to idle refresh behavior. |
 | `CROWDSEC_FULL_REFRESH_INTERVAL` | `5m` | Interval for full cache refreshes while active. |
 | `CROWDSEC_LAPI_REQUEST_TIMEOUT` | `30s` | Timeout for individual CrowdSec LAPI requests. Increase this for high-latency or very large CrowdSec datasets. |
+| `CROWDSEC_HEARTBEAT_INTERVAL` | `30s` | Interval for updating the Web UI machine heartbeat in CrowdSec. Use `0` or `manual` to disable heartbeat updates. |
 | `CROWDSEC_ALERT_SYNC_CHUNK` | `6h` | Window size used when syncing historical and active-decision alerts from LAPI. Smaller chunks reduce per-request payload size. |
 | `CROWDSEC_ALERT_SYNC_MIN_CHUNK` | `15m` | Smallest window size used when retrying timed-out alert sync windows. |
 | `CROWDSEC_BOOTSTRAP_RETRY_DELAY` | `30s` | Delay between background retries when initial CrowdSec bootstrap fails. |

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -411,6 +411,9 @@ function createController(options: {
     if (url.endsWith('/v1/watchers/login')) {
       return Response.json({ code: 200, token: 'token' });
     }
+    if (url.endsWith('/v1/usage-metrics') && init?.method === 'POST') {
+      return Response.json({ ok: true }, { status: 201 });
+    }
     if (url.includes('/v1/alerts?')) {
       return Response.json([]);
     }
@@ -1692,6 +1695,54 @@ describe('createApp', () => {
     controller.stopBackgroundTasks();
     database.close();
     destroyTempDir();
+  });
+
+  test('starts a CrowdSec machine heartbeat with background tasks', async () => {
+    const { controller, database, lapiClient, fetchCalls } = createController({
+      env: {
+        CROWDSEC_REFRESH_INTERVAL: 'manual',
+        CROWDSEC_HEARTBEAT_INTERVAL: '5s',
+      },
+    });
+
+    await lapiClient.login();
+    vi.useFakeTimers();
+
+    try {
+      controller.startBackgroundTasks();
+      await vi.advanceTimersByTimeAsync(0);
+
+      const heartbeatRequest = fetchCalls.find((call) => call.url.endsWith('/v1/heartbeat'));
+      const usageMetricsRequest = fetchCalls.find((call) => call.url.endsWith('/v1/usage-metrics'));
+      expect(heartbeatRequest).toEqual(expect.objectContaining({
+        method: 'GET',
+      }));
+      expect(heartbeatRequest?.headers).toEqual(expect.objectContaining({
+        Authorization: 'Bearer token',
+      }));
+      expect(usageMetricsRequest).toEqual(expect.objectContaining({
+        method: 'POST',
+        body: expect.objectContaining({
+          log_processors: [
+            expect.objectContaining({
+              os: expect.objectContaining({
+                name: expect.any(String),
+                version: expect.any(String),
+              }),
+              version: '1.0.0',
+            }),
+          ],
+        }),
+      }));
+      expect(usageMetricsRequest?.headers).toEqual(expect.objectContaining({
+        Authorization: 'Bearer token',
+      }));
+    } finally {
+      controller.stopBackgroundTasks();
+      vi.useRealTimers();
+      database.close();
+      destroyTempDir();
+    }
   });
 
   test('normalizes array-shaped alert detail payloads to a single alert', async () => {

--- a/server/app.ts
+++ b/server/app.ts
@@ -367,6 +367,10 @@ export function createApp(options: CreateAppOptions = {}): AppController {
   let lastFullRefreshTime = Date.now();
   let schedulerTimeout: ReturnType<typeof setTimeout> | null = null;
   let isSchedulerRunning = false;
+  let heartbeatTimeout: ReturnType<typeof setTimeout> | null = null;
+  let isHeartbeatSchedulerRunning = false;
+  let heartbeatPromise: Promise<void> | null = null;
+  let heartbeatFailureLogged = false;
   let bootstrapRetryTimeout: ReturnType<typeof setTimeout> | null = null;
   let bootstrapPromise: Promise<boolean> | null = null;
   let bootstrapWaitLogged = false;
@@ -377,6 +381,7 @@ export function createApp(options: CreateAppOptions = {}): AppController {
   LAPI Request Timeout: ${getIntervalName(config.lapiRequestTimeoutMs)}
   Alert Sync Chunk: ${getIntervalName(config.alertSyncChunkMs)}
   Alert Sync Min Chunk: ${getIntervalName(config.alertSyncMinChunkMs)}
+  Machine Heartbeat: ${config.heartbeatIntervalMs > 0 ? getIntervalName(config.heartbeatIntervalMs) : 'Disabled'}
   Auth Mode: ${config.crowdsecAuthMode}
   Simulations: ${config.simulationsEnabled ? 'Enabled' : 'Disabled'}
   Alert Filter Mode: ${config.alertFilterMode}
@@ -2121,6 +2126,74 @@ ${errorSummary}  Status: ${syncSummary.state}
     }
   }
 
+  async function sendMachineHeartbeat(): Promise<void> {
+    if (!lapiClient.hasAuthConfig()) {
+      return;
+    }
+
+    if (heartbeatPromise) {
+      return heartbeatPromise;
+    }
+
+    heartbeatPromise = (async () => {
+      try {
+        await lapiClient.heartbeat();
+        await lapiClient.sendUsageMetrics();
+        if (heartbeatFailureLogged) {
+          console.log('CrowdSec machine heartbeat restored.');
+        }
+        heartbeatFailureLogged = false;
+      } catch (error: any) {
+        const message = error?.message || 'Unknown error';
+        if (!heartbeatFailureLogged) {
+          console.warn(`CrowdSec machine heartbeat or metrics update failed: ${message}`);
+        }
+        heartbeatFailureLogged = true;
+      } finally {
+        heartbeatPromise = null;
+      }
+    })();
+
+    return heartbeatPromise;
+  }
+
+  async function runHeartbeatLoop(): Promise<void> {
+    if (!isHeartbeatSchedulerRunning) return;
+
+    await sendMachineHeartbeat();
+
+    if (!isHeartbeatSchedulerRunning || config.heartbeatIntervalMs <= 0) return;
+
+    heartbeatTimeout = setTimeout(() => {
+      void runHeartbeatLoop();
+    }, config.heartbeatIntervalMs);
+  }
+
+  function startHeartbeatScheduler(): void {
+    stopHeartbeatScheduler(false);
+    if (config.heartbeatIntervalMs <= 0) {
+      console.log('CrowdSec machine heartbeat disabled.');
+      return;
+    }
+
+    console.log(`Starting CrowdSec machine heartbeat (${getIntervalName(config.heartbeatIntervalMs)})...`);
+    isHeartbeatSchedulerRunning = true;
+    heartbeatTimeout = setTimeout(() => {
+      void runHeartbeatLoop();
+    }, 0);
+  }
+
+  function stopHeartbeatScheduler(logStop = true): void {
+    if (logStop && (isHeartbeatSchedulerRunning || heartbeatTimeout)) {
+      console.log('Stopping CrowdSec machine heartbeat...');
+    }
+    isHeartbeatSchedulerRunning = false;
+    if (heartbeatTimeout) {
+      clearTimeout(heartbeatTimeout);
+      heartbeatTimeout = null;
+    }
+  }
+
   async function activityTrackerMiddleware(context: HonoContext, next: HonoNext): Promise<void> {
     const now = Date.now();
     const wasIdle = now - lastRequestTime > config.idleThresholdMs;
@@ -2739,7 +2812,10 @@ ${errorSummary}  Status: ${syncSummary.state}
     database,
     lapiClient,
     startBackgroundTasks,
-    stopBackgroundTasks: () => stopRefreshScheduler(),
+    stopBackgroundTasks: () => {
+      stopRefreshScheduler();
+      stopHeartbeatScheduler();
+    },
     getSyncStatus: () => ({ ...syncStatus }),
     getLapiStatus: () => lapiClient.getStatus(),
   };
@@ -2749,6 +2825,7 @@ ${errorSummary}  Status: ${syncSummary.state}
       console.warn('Cache initialization skipped - CrowdSec LAPI authentication not configured');
       return;
     }
+    startHeartbeatScheduler();
     startRefreshScheduler();
     void ensureBootstrapReady('startup');
   }

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -61,6 +61,7 @@ describe('config helpers', () => {
       CROWDSEC_IDLE_THRESHOLD: '30s',
       CROWDSEC_FULL_REFRESH_INTERVAL: '5m',
       CROWDSEC_LAPI_REQUEST_TIMEOUT: '2m',
+      CROWDSEC_HEARTBEAT_INTERVAL: '1m',
       CROWDSEC_ALERT_SYNC_CHUNK: '3h',
       CROWDSEC_ALERT_SYNC_MIN_CHUNK: '30m',
       CROWDSEC_BOOTSTRAP_RETRY_DELAY: '1m',
@@ -91,6 +92,7 @@ describe('config helpers', () => {
     expect(config.lookbackMs).toBe(172_800_000);
     expect(config.refreshIntervalMs).toBe(5_000);
     expect(config.lapiRequestTimeoutMs).toBe(120_000);
+    expect(config.heartbeatIntervalMs).toBe(60_000);
     expect(config.alertSyncChunkMs).toBe(10_800_000);
     expect(config.alertSyncMinChunkMs).toBe(1_800_000);
     expect(config.bootstrapRetryEnabled).toBe(false);
@@ -119,6 +121,7 @@ describe('config helpers', () => {
     expect(config.notificationAllowPrivateAddresses).toBe(true);
     expect(config.notificationDebugPayloads).toBe(false);
     expect(config.lapiRequestTimeoutMs).toBe(30_000);
+    expect(config.heartbeatIntervalMs).toBe(30_000);
     expect(config.alertSyncChunkMs).toBe(21_600_000);
     expect(config.alertSyncMinChunkMs).toBe(900_000);
   });

--- a/server/config.ts
+++ b/server/config.ts
@@ -27,6 +27,7 @@ export interface RuntimeConfig {
   idleThresholdMs: number;
   fullRefreshIntervalMs: number;
   lapiRequestTimeoutMs: number;
+  heartbeatIntervalMs: number;
   alertSyncChunkMs: number;
   alertSyncMinChunkMs: number;
   bootstrapRetryDelayMs: number;
@@ -240,6 +241,7 @@ export function createRuntimeConfig(env: NodeJS.ProcessEnv = process.env): Runti
     idleThresholdMs: parseRefreshInterval(env.CROWDSEC_IDLE_THRESHOLD || '2m'),
     fullRefreshIntervalMs: parseRefreshInterval(env.CROWDSEC_FULL_REFRESH_INTERVAL || '5m'),
     lapiRequestTimeoutMs: parsePositiveIntervalEnv(env.CROWDSEC_LAPI_REQUEST_TIMEOUT, '30s'),
+    heartbeatIntervalMs: parseRefreshInterval(env.CROWDSEC_HEARTBEAT_INTERVAL || '30s'),
     alertSyncChunkMs: parsePositiveIntervalEnv(env.CROWDSEC_ALERT_SYNC_CHUNK, '6h'),
     alertSyncMinChunkMs: parsePositiveIntervalEnv(env.CROWDSEC_ALERT_SYNC_MIN_CHUNK, '15m'),
     bootstrapRetryDelayMs: parseRefreshInterval(env.CROWDSEC_BOOTSTRAP_RETRY_DELAY || '30s'),

--- a/server/lapi.test.ts
+++ b/server/lapi.test.ts
@@ -260,6 +260,106 @@ describe('LapiClient', () => {
     expect(calls.some((call) => call.url.endsWith('/v1/decisions/10') && call.method === 'DELETE')).toBe(true);
   });
 
+  test('sends machine heartbeats with the stored watcher token', async () => {
+    const calls: Array<{ url: string; method: string; authorization?: string }> = [];
+    const client = new LapiClient({
+      crowdsecUrl: 'http://crowdsec:8080',
+      auth: passwordAuth,
+      simulationsEnabled: true,
+      lookbackPeriod: '1h',
+      version: '1.0.0',
+      fetchImpl: async (input, init) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        calls.push({
+          url: String(input),
+          method: init?.method || 'GET',
+          authorization: headers?.Authorization,
+        });
+
+        if (String(input).endsWith('/v1/watchers/login')) {
+          return Response.json({ code: 200, token: 'heartbeat-token' });
+        }
+
+        return Response.json({});
+      },
+    });
+
+    await client.login();
+    await client.heartbeat();
+
+    expect(calls).toEqual([
+      expect.objectContaining({
+        url: 'http://crowdsec:8080/v1/watchers/login',
+        method: 'POST',
+      }),
+      {
+        url: 'http://crowdsec:8080/v1/heartbeat',
+        method: 'GET',
+        authorization: 'Bearer heartbeat-token',
+      },
+    ]);
+    expect(client.getStatus().isConnected).toBe(true);
+  });
+
+  test('sends usage metrics with machine OS details', async () => {
+    const calls: Array<{ url: string; method: string; authorization?: string; body?: unknown }> = [];
+    const client = new LapiClient({
+      crowdsecUrl: 'http://crowdsec:8080',
+      auth: passwordAuth,
+      simulationsEnabled: true,
+      lookbackPeriod: '1h',
+      version: '1.2.3',
+      machineInfo: {
+        os: {
+          name: 'debian (docker)',
+          family: 'debian',
+          version: '12.13',
+        },
+      },
+      fetchImpl: async (input, init) => {
+        const headers = init?.headers as Record<string, string> | undefined;
+        calls.push({
+          url: String(input),
+          method: init?.method || 'GET',
+          authorization: headers?.Authorization,
+          body: init?.body ? JSON.parse(String(init.body)) : undefined,
+        });
+
+        if (String(input).endsWith('/v1/watchers/login')) {
+          return Response.json({ code: 200, token: 'metrics-token' });
+        }
+
+        return Response.json({ ok: true }, { status: String(input).endsWith('/v1/usage-metrics') ? 201 : 200 });
+      },
+    });
+
+    await client.login();
+    await client.sendUsageMetrics();
+
+    expect(calls[1]).toEqual({
+      url: 'http://crowdsec:8080/v1/usage-metrics',
+      method: 'POST',
+      authorization: 'Bearer metrics-token',
+      body: {
+        log_processors: [
+          {
+            version: '1.2.3',
+            os: {
+              name: 'debian (docker)',
+              family: 'debian',
+              version: '12.13',
+            },
+            utc_startup_timestamp: expect.any(Number),
+            metrics: [],
+            feature_flags: [],
+            datasources: {},
+            hub_items: {},
+          },
+        ],
+      },
+    });
+  });
+
   test('throws when all alert scope requests fail', async () => {
     const client = new LapiClient({
       crowdsecUrl: 'http://crowdsec:8080',

--- a/server/lapi.ts
+++ b/server/lapi.ts
@@ -1,4 +1,5 @@
 import fs from 'node:fs';
+import os from 'node:os';
 import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
 import type { LapiStatus } from '../shared/contracts';
 import type { CrowdsecAuthConfig } from './auth';
@@ -29,6 +30,7 @@ export interface LapiClientOptions {
   lookbackPeriod: string;
   requestTimeoutMs?: number;
   version: string;
+  machineInfo?: MachineInfo;
   fetchImpl?: FetchLike;
 }
 
@@ -40,11 +42,73 @@ export interface FetchAlertsFilters {
   requireAllScopes?: boolean;
 }
 
+interface MachineInfo {
+  os: {
+    name: string;
+    family?: string;
+    version: string;
+  };
+}
+
+function parseOsReleaseValue(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    return trimmed.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  }
+  return trimmed;
+}
+
+function parseOsRelease(content: string): Record<string, string> {
+  const values: Record<string, string> = {};
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const separatorIndex = trimmed.indexOf('=');
+    if (separatorIndex <= 0) continue;
+    const key = trimmed.slice(0, separatorIndex);
+    const value = parseOsReleaseValue(trimmed.slice(separatorIndex + 1));
+    if (value) {
+      values[key] = value;
+    }
+  }
+  return values;
+}
+
+function detectMachineInfo(): MachineInfo {
+  let osName: string = os.platform();
+  let osFamily: string = os.type();
+  let osVersion: string = os.release();
+
+  try {
+    const release = parseOsRelease(fs.readFileSync('/etc/os-release', 'utf8'));
+    osName = release.ID || release.NAME || osName;
+    osFamily = release.ID_LIKE || release.ID || osFamily;
+    osVersion = release.VERSION_ID || release.VERSION || osVersion;
+  } catch {
+    // Fall back to Node's platform details when distro metadata is unavailable.
+  }
+
+  if (fs.existsSync('/.dockerenv') || fs.existsSync('/run/.containerenv')) {
+    osName = `${osName} (docker)`;
+  }
+
+  return {
+    os: {
+      name: osName,
+      family: osFamily,
+      version: osVersion,
+    },
+  };
+}
+
 export class LapiClient {
   private readonly crowdsecUrl: string;
   private readonly auth: CrowdsecAuthConfig;
   private readonly simulationsEnabled: boolean;
   private readonly version: string;
+  private readonly machineInfo: MachineInfo;
+  private readonly startupTimestamp: number;
   private readonly requestTimeoutMs: number;
   private readonly fetchImpl: FetchLike;
   private readonly dispatcher?: Dispatcher;
@@ -65,6 +129,8 @@ export class LapiClient {
     this.simulationsEnabled = options.simulationsEnabled ?? false;
     this.lookbackPeriod = options.lookbackPeriod;
     this.version = options.version;
+    this.machineInfo = options.machineInfo || detectMachineInfo();
+    this.startupTimestamp = Math.floor(Date.now() / 1_000);
     this.requestTimeoutMs = options.requestTimeoutMs || 30_000;
     this.fetchImpl = options.fetchImpl || ((input, init) =>
       undiciFetch(
@@ -225,6 +291,37 @@ export class LapiClient {
     })();
 
     return this.loginPromise;
+  }
+
+  async heartbeat(): Promise<void> {
+    try {
+      await this.fetchLapi('/v1/heartbeat');
+      this.updateStatus(true);
+    } catch (error: any) {
+      this.updateStatus(false, error);
+      throw error;
+    }
+  }
+
+  async sendUsageMetrics(): Promise<void> {
+    const payload = {
+      log_processors: [
+        {
+          version: this.version || '0.0.0',
+          os: this.machineInfo.os,
+          utc_startup_timestamp: this.startupTimestamp,
+          metrics: [],
+          feature_flags: [],
+          datasources: {},
+          hub_items: {},
+        },
+      ],
+    };
+
+    await this.fetchLapi('/v1/usage-metrics', {
+      method: 'POST',
+      body: payload,
+    });
   }
 
   async fetchAlerts(


### PR DESCRIPTION
Send periodic machine heartbeats and usage metrics so CrowdSec can show the Web UI machine as healthy with OS metadata.

Closes #267