### PR TITLE
Add support for configurable OIDC authorization scopes (`oidcScope`)

### DIFF
--- a/API.md
+++ b/API.md
@@ -66,7 +66,7 @@ These routes are mounted below `/api/auth`. Auth setup/login routes are availabl
 | POST | `/api/auth/logout` | Clear the session cookie. |
 | GET | `/api/auth/me` | Current authenticated session user. |
 | GET | `/api/auth/settings` | Auth settings visible to the current user, including OIDC settings metadata and password/passkey state. |
-| PUT | `/api/auth/settings` | Admin-only auth settings update. Can disable password login and configure OIDC issuer, client ID, client secret, groups claim, admin groups, read-only groups, and unmatched-user policy. |
+| PUT | `/api/auth/settings` | Admin-only auth settings update. Can disable password login and configure OIDC issuer, client ID, client secret, scopes, groups claim, admin groups, read-only groups, and unmatched-user policy. |
 | POST | `/api/auth/change-password` | Change the current user's password. The user must be logged in with password auth. |
 | GET | `/api/auth/passkeys` | List passkeys for the current user. |
 | PATCH | `/api/auth/passkeys/:id` | Rename a passkey with `{ "name": "..." }`. |

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ Choose exactly one auth mode: password auth or mTLS auth.
 | `CROWDSEC_AUTH_OIDC_CLIENT_ID` | none | Optional OIDC client ID. Can also be configured from Settings. |
 | `CROWDSEC_AUTH_OIDC_CLIENT_SECRET` | none | Optional OIDC client secret. Can also be configured from Settings. |
 | `CROWDSEC_AUTH_OIDC_CLIENT_SECRET_FILE` | none | Optional Docker Secrets alternative: read `CROWDSEC_AUTH_OIDC_CLIENT_SECRET` from a file. Do not set both variables. |
+| `CROWDSEC_AUTH_OIDC_SCOPE` | `openid profile email groups` | Optional OIDC authorization scope string. Can also be configured from Settings. |
 | `CROWDSEC_AUTH_OIDC_GROUPS_CLAIM` | `groups` | Optional OIDC claim used for group mapping. The claim may be an array or a comma-separated string. Can also be configured from Settings. |
 | `CROWDSEC_AUTH_OIDC_ADMIN_GROUPS` | empty | Optional comma-separated OIDC groups that receive admin permissions. Can also be configured from Settings. |
 | `CROWDSEC_AUTH_OIDC_READ_ONLY_GROUPS` | empty | Optional comma-separated OIDC groups that receive read-only permissions. Can also be configured from Settings. |
@@ -315,13 +316,14 @@ AUTH_ENABLED=true
 CROWDSEC_AUTH_OIDC_ISSUER_URL=https://idp.example.com/application/o/crowdsec-web-ui/
 CROWDSEC_AUTH_OIDC_CLIENT_ID=crowdsec-web-ui
 CROWDSEC_AUTH_OIDC_CLIENT_SECRET=change-me
+CROWDSEC_AUTH_OIDC_SCOPE="openid profile email groups"
 CROWDSEC_AUTH_OIDC_GROUPS_CLAIM=groups
 CROWDSEC_AUTH_OIDC_ADMIN_GROUPS=crowdsec-admins,secops
 CROWDSEC_AUTH_OIDC_READ_ONLY_GROUPS=crowdsec-viewers
 CROWDSEC_AUTH_OIDC_UNMATCHED_ROLE=deny
 ```
 
-OIDC Settings accepts the issuer URL, client ID, client secret, groups claim, admin groups, read-only groups, and the unmatched-user policy. Saved Settings values override OIDC environment defaults. By default, OIDC users who match no configured group are denied. Set the unmatched-user policy to `admin` or `read-only` only when every user who can complete OIDC sign-in should receive that fallback role.
+OIDC Settings accepts the issuer URL, client ID, client secret, authorization scopes, groups claim, admin groups, read-only groups, and the unmatched-user policy. Saved Settings values override OIDC environment defaults. By default, OIDC users who match no configured group are denied. Set the unmatched-user policy to `admin` or `read-only` only when every user who can complete OIDC sign-in should receive that fallback role.
 
 OIDC group mapping is lightweight RBAC. `PERMISSION_READ_ONLY=true` is still instance-wide and overrides user roles. For OIDC, admin group matches get full access, read-only group matches can view data and keep allowed preferences, and users with no matching group follow `CROWDSEC_AUTH_OIDC_UNMATCHED_ROLE`.
 

--- a/client/src/locales/ar.json
+++ b/client/src/locales/ar.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "معرّف العميل",
   "pages.settings.oidcClientSecret": "سر العميل",
   "pages.settings.unchanged": "(بدون تغيير)",
+  "pages.settings.oidcScope": "نطاقات OIDC",
   "pages.settings.oidcGroupsClaim": "مطالبة المجموعات",
   "pages.settings.oidcAdminGroups": "مجموعات المسؤولين",
   "pages.settings.oidcReadOnlyGroups": "مجموعات القراءة فقط",

--- a/client/src/locales/de.json
+++ b/client/src/locales/de.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "Client-Kennung",
   "pages.settings.oidcClientSecret": "Client-Geheimnis",
   "pages.settings.unchanged": "(unverändert)",
+  "pages.settings.oidcScope": "OIDC-Scopes",
   "pages.settings.oidcGroupsClaim": "Gruppenattribut",
   "pages.settings.oidcAdminGroups": "Admin-Gruppen",
   "pages.settings.oidcReadOnlyGroups": "Nur-Lese-Gruppen",

--- a/client/src/locales/en.json
+++ b/client/src/locales/en.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "Client ID",
   "pages.settings.oidcClientSecret": "Client Secret",
   "pages.settings.unchanged": "(unchanged)",
+  "pages.settings.oidcScope": "Scopes",
   "pages.settings.oidcGroupsClaim": "Groups Claim",
   "pages.settings.oidcAdminGroups": "Admin Groups",
   "pages.settings.oidcReadOnlyGroups": "Read-only Groups",

--- a/client/src/locales/es.json
+++ b/client/src/locales/es.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "ID de cliente",
   "pages.settings.oidcClientSecret": "Secreto de cliente",
   "pages.settings.unchanged": "(sin cambios)",
+  "pages.settings.oidcScope": "Scopes OIDC",
   "pages.settings.oidcGroupsClaim": "Atributo de grupos",
   "pages.settings.oidcAdminGroups": "Grupos de administradores",
   "pages.settings.oidcReadOnlyGroups": "Grupos de solo lectura",

--- a/client/src/locales/fr.json
+++ b/client/src/locales/fr.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "ID client",
   "pages.settings.oidcClientSecret": "Secret client",
   "pages.settings.unchanged": "(inchangé)",
+  "pages.settings.oidcScope": "Scopes OIDC",
   "pages.settings.oidcGroupsClaim": "Attribut des groupes",
   "pages.settings.oidcAdminGroups": "Groupes administrateurs",
   "pages.settings.oidcReadOnlyGroups": "Groupes en lecture seule",

--- a/client/src/locales/hi.json
+++ b/client/src/locales/hi.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "क्लाइंट ID",
   "pages.settings.oidcClientSecret": "क्लाइंट सीक्रेट",
   "pages.settings.unchanged": "(बदला नहीं गया)",
+  "pages.settings.oidcScope": "OIDC स्कोप",
   "pages.settings.oidcGroupsClaim": "समूह दावा",
   "pages.settings.oidcAdminGroups": "एडमिन समूह",
   "pages.settings.oidcReadOnlyGroups": "रीड-ओनली समूह",

--- a/client/src/locales/ja.json
+++ b/client/src/locales/ja.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "クライアント ID",
   "pages.settings.oidcClientSecret": "クライアントシークレット",
   "pages.settings.unchanged": "(変更なし)",
+  "pages.settings.oidcScope": "OIDC スコープ",
   "pages.settings.oidcGroupsClaim": "グループクレーム",
   "pages.settings.oidcAdminGroups": "管理者グループ",
   "pages.settings.oidcReadOnlyGroups": "読み取り専用グループ",

--- a/client/src/locales/pt.json
+++ b/client/src/locales/pt.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "ID do cliente",
   "pages.settings.oidcClientSecret": "Segredo do cliente",
   "pages.settings.unchanged": "(inalterado)",
+  "pages.settings.oidcScope": "Scopes OIDC",
   "pages.settings.oidcGroupsClaim": "Atributo de grupos",
   "pages.settings.oidcAdminGroups": "Grupos de administradores",
   "pages.settings.oidcReadOnlyGroups": "Grupos somente leitura",

--- a/client/src/locales/ru.json
+++ b/client/src/locales/ru.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "Идентификатор клиента",
   "pages.settings.oidcClientSecret": "Секрет клиента",
   "pages.settings.unchanged": "(без изменений)",
+  "pages.settings.oidcScope": "OIDC scopes",
   "pages.settings.oidcGroupsClaim": "Утверждение групп",
   "pages.settings.oidcAdminGroups": "Группы администраторов",
   "pages.settings.oidcReadOnlyGroups": "Группы только для чтения",

--- a/client/src/locales/zh.json
+++ b/client/src/locales/zh.json
@@ -269,6 +269,7 @@
   "pages.settings.oidcClientId": "客户端 ID",
   "pages.settings.oidcClientSecret": "客户端密钥",
   "pages.settings.unchanged": "（未更改）",
+  "pages.settings.oidcScope": "OIDC 作用域",
   "pages.settings.oidcGroupsClaim": "组声明",
   "pages.settings.oidcAdminGroups": "管理员组",
   "pages.settings.oidcReadOnlyGroups": "只读组",

--- a/client/src/pages/Settings.test.tsx
+++ b/client/src/pages/Settings.test.tsx
@@ -61,6 +61,7 @@ const { setLanguagePreferenceMock, tMock, useAuthMock } = vi.hoisted(() => {
     'pages.settings.oidcClientId': 'Client ID',
     'pages.settings.oidcClientSecret': 'Client Secret',
     'pages.settings.unchanged': '(unchanged)',
+    'pages.settings.oidcScope': 'Scopes',
     'pages.settings.oidcGroupsClaim': 'Groups Claim',
     'pages.settings.oidcAdminGroups': 'Admin Groups',
     'pages.settings.oidcReadOnlyGroups': 'Read-only Groups',
@@ -288,6 +289,7 @@ describe('Settings', () => {
           oidcIssuerUrl: '',
           oidcClientId: '',
           hasOidcClientSecret: false,
+          oidcScope: 'openid profile email groups',
           oidcGroupsClaim: 'groups',
           oidcAdminGroups: '',
           oidcReadOnlyGroups: '',
@@ -351,6 +353,7 @@ describe('Settings', () => {
           oidcIssuerUrl: '',
           oidcClientId: '',
           hasOidcClientSecret: false,
+          oidcScope: 'openid profile email groups',
           oidcGroupsClaim: 'groups',
           oidcAdminGroups: '',
           oidcReadOnlyGroups: '',
@@ -450,6 +453,7 @@ describe('Settings', () => {
           oidcIssuerUrl: '',
           oidcClientId: '',
           hasOidcClientSecret: false,
+          oidcScope: 'openid profile email groups',
           oidcGroupsClaim: 'groups',
           oidcAdminGroups: '',
           oidcReadOnlyGroups: '',
@@ -533,6 +537,7 @@ describe('Settings', () => {
           oidcIssuerUrl: 'https://idp.example.com',
           oidcClientId: 'crowdsec',
           hasOidcClientSecret: false,
+          oidcScope: 'openid profile email groups',
           oidcGroupsClaim: 'groups',
           oidcAdminGroups: 'Application Admin,secops',
           oidcReadOnlyGroups: 'Application User',
@@ -551,6 +556,8 @@ describe('Settings', () => {
     expect(screen.getByLabelText('Unmatched OIDC users')).toHaveValue('deny');
     expect(screen.getByLabelText('Unmatched OIDC users')).toHaveAccessibleDescription('Choose what happens when an OIDC user matches no configured group. The default is deny sign-in.');
     await user.click(screen.getByRole('button', { name: 'Remove secops' }));
+    await user.clear(screen.getByLabelText('Scopes'));
+    await user.type(screen.getByLabelText('Scopes'), 'openid profile email groups offline_access');
     await user.type(screen.getByLabelText('Admin Groups'), 'security-team');
     await user.click(screen.getAllByRole('button', { name: 'Add' })[0]);
     await user.selectOptions(screen.getByLabelText('Unmatched OIDC users'), 'admin');
@@ -564,6 +571,7 @@ describe('Settings', () => {
           oidcIssuerUrl: 'https://idp.example.com',
           oidcClientId: 'crowdsec',
           oidcClientSecret: '',
+          oidcScope: 'openid profile email groups offline_access',
           oidcGroupsClaim: 'groups',
           oidcAdminGroups: 'Application Admin,security-team',
           oidcReadOnlyGroups: 'Application User',

--- a/client/src/pages/Settings.tsx
+++ b/client/src/pages/Settings.tsx
@@ -44,6 +44,7 @@ interface AuthSettings {
     oidcIssuerUrl: string;
     oidcClientId: string;
     hasOidcClientSecret: boolean;
+    oidcScope: string;
     oidcGroupsClaim: string;
     oidcAdminGroups: string;
     oidcReadOnlyGroups: string;
@@ -89,6 +90,7 @@ export function Settings() {
         issuerUrl: '',
         clientId: '',
         clientSecret: '',
+        scope: 'openid profile email groups',
         groupsClaim: 'groups',
         adminGroups: [] as string[],
         readOnlyGroups: [] as string[],
@@ -143,6 +145,7 @@ export function Settings() {
                             issuerUrl: payload.oidcIssuerUrl,
                             clientId: payload.oidcClientId,
                             clientSecret: '',
+                            scope: payload.oidcScope || 'openid profile email groups',
                             groupsClaim: payload.oidcGroupsClaim || 'groups',
                             adminGroups: parseGroupList(payload.oidcAdminGroups || ''),
                             readOnlyGroups: parseGroupList(payload.oidcReadOnlyGroups || ''),
@@ -325,6 +328,7 @@ export function Settings() {
                     oidcIssuerUrl: oidcForm.issuerUrl,
                     oidcClientId: oidcForm.clientId,
                     oidcClientSecret: oidcForm.clientSecret,
+                    oidcScope: oidcForm.scope,
                     oidcGroupsClaim: oidcForm.groupsClaim,
                     oidcAdminGroups: adminGroups,
                     oidcReadOnlyGroups: readOnlyGroups,
@@ -346,6 +350,7 @@ export function Settings() {
                 oidcIssuerUrl: oidcForm.issuerUrl.trim(),
                 oidcClientId: oidcForm.clientId.trim(),
                 hasOidcClientSecret: Boolean(oidcForm.clientSecret.trim()) || current.hasOidcClientSecret,
+                oidcScope: oidcForm.scope.trim() || 'openid profile email groups',
                 oidcGroupsClaim: oidcForm.groupsClaim.trim() || 'groups',
                 oidcAdminGroups: adminGroups,
                 oidcReadOnlyGroups: readOnlyGroups,
@@ -650,6 +655,17 @@ export function Settings() {
                                         value={oidcForm.clientSecret}
                                         onChange={(event) => setOidcForm((current) => ({ ...current, clientSecret: event.target.value }))}
                                         placeholder={authSettings?.hasOidcClientSecret ? t("pages.settings.unchanged") : ''}
+                                        disabled={!canManageAuthSettings}
+                                        className={inputClass}
+                                    />
+                                </div>
+                                <div className="space-y-2 lg:col-span-2">
+                                    <label htmlFor="oidc-scope" className={labelClass}>{t("pages.settings.oidcScope")}</label>
+                                    <input
+                                        id="oidc-scope"
+                                        value={oidcForm.scope}
+                                        onChange={(event) => setOidcForm((current) => ({ ...current, scope: event.target.value }))}
+                                        placeholder="openid profile email groups"
                                         disabled={!canManageAuthSettings}
                                         className={inputClass}
                                     />

--- a/server/app-auth.ts
+++ b/server/app-auth.ts
@@ -23,6 +23,7 @@ type MutableAuthSettingKey =
   | 'oidc_issuer_url'
   | 'oidc_client_id'
   | 'oidc_client_secret'
+  | 'oidc_scope'
   | 'oidc_groups_claim'
   | 'oidc_admin_groups'
   | 'oidc_read_only_groups'
@@ -32,6 +33,7 @@ interface EffectiveAuthConfig {
   oidcIssuerUrl?: string;
   oidcClientId?: string;
   oidcClientSecret?: string;
+  oidcScope: string;
   oidcGroupsClaim: string;
   oidcAdminGroups: string[];
   oidcReadOnlyGroups: string[];
@@ -376,7 +378,7 @@ class OidcRuntime {
       client_id: config.oidcClientId!,
       redirect_uri: redirectUri,
       response_type: 'code',
-      scope: 'openid profile email',
+      scope: config.oidcScope,
       state,
       nonce,
     });
@@ -430,6 +432,7 @@ export function createDashboardAuth(options: {
       oidcIssuerUrl: readAuthSetting(database, 'oidc_issuer_url') ?? config.oidcIssuerUrl,
       oidcClientId: readAuthSetting(database, 'oidc_client_id') ?? config.oidcClientId,
       oidcClientSecret,
+      oidcScope: readAuthSetting(database, 'oidc_scope')?.trim() || config.oidcScope,
       oidcGroupsClaim: readAuthSetting(database, 'oidc_groups_claim') || config.oidcGroupsClaim || 'groups',
       oidcAdminGroups: parseCsvList(readAuthSetting(database, 'oidc_admin_groups') ?? config.oidcAdminGroups.join(',')),
       oidcReadOnlyGroups: parseCsvList(readAuthSetting(database, 'oidc_read_only_groups') ?? config.oidcReadOnlyGroups.join(',')),
@@ -604,6 +607,7 @@ export function createDashboardAuth(options: {
         oidcIssuerUrl: effectiveConfig.oidcIssuerUrl || '',
         oidcClientId: effectiveConfig.oidcClientId || '',
         hasOidcClientSecret: Boolean(effectiveConfig.oidcClientSecret),
+        oidcScope: effectiveConfig.oidcScope,
         oidcGroupsClaim: effectiveConfig.oidcGroupsClaim,
         oidcAdminGroups: effectiveConfig.oidcAdminGroups.join(','),
         oidcReadOnlyGroups: effectiveConfig.oidcReadOnlyGroups.join(','),
@@ -638,6 +642,13 @@ export function createDashboardAuth(options: {
           ? body.oidcGroupsClaim.trim()
           : 'groups';
         writeAuthSetting(database, 'oidc_groups_claim', groupsClaim);
+      }
+
+      if ('oidcScope' in body) {
+        const scope = typeof body.oidcScope === 'string' && body.oidcScope.trim()
+          ? body.oidcScope.trim()
+          : config.oidcScope;
+        writeAuthSetting(database, 'oidc_scope', scope);
       }
 
       if ('oidcAdminGroups' in body) {
@@ -693,6 +704,7 @@ export function createDashboardAuth(options: {
           oidcIssuerUrl: effectiveConfig.oidcIssuerUrl || '',
           oidcClientId: effectiveConfig.oidcClientId || '',
           hasOidcClientSecret: Boolean(effectiveConfig.oidcClientSecret),
+          oidcScope: effectiveConfig.oidcScope,
           oidcGroupsClaim: effectiveConfig.oidcGroupsClaim,
           oidcAdminGroups: effectiveConfig.oidcAdminGroups.join(','),
           oidcReadOnlyGroups: effectiveConfig.oidcReadOnlyGroups.join(','),

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -625,6 +625,7 @@ test('dashboard auth exposes account settings and password changes', async () =>
     oidcIssuerUrl: '',
     oidcClientId: '',
     hasOidcClientSecret: false,
+    oidcScope: 'openid profile email groups',
     oidcGroupsClaim: 'groups',
     oidcAdminGroups: '',
     oidcReadOnlyGroups: '',
@@ -660,6 +661,7 @@ test('dashboard auth exposes account settings and password changes', async () =>
     headers: { 'Content-Type': 'application/json', cookie },
     body: JSON.stringify({
       oidcGroupsClaim: 'roles',
+      oidcScope: 'openid profile email groups offline_access',
       oidcAdminGroups: 'admins, secops, admins',
       oidcReadOnlyGroups: 'viewers',
       oidcUnmatchedRole: 'admin',
@@ -669,6 +671,7 @@ test('dashboard auth exposes account settings and password changes', async () =>
   expect(await saveGroupMapping.json()).toMatchObject({
     settings: {
       oidcGroupsClaim: 'roles',
+      oidcScope: 'openid profile email groups offline_access',
       oidcAdminGroups: 'admins,secops',
       oidcReadOnlyGroups: 'viewers',
       oidcUnmatchedRole: 'admin',
@@ -718,6 +721,7 @@ test('dashboard auth settings use OIDC environment values as defaults', async ()
       CROWDSEC_AUTH_OIDC_ISSUER_URL: 'https://idp.example.com/application/o/crowdsec/',
       CROWDSEC_AUTH_OIDC_CLIENT_ID: 'crowdsec-client',
       CROWDSEC_AUTH_OIDC_CLIENT_SECRET: 'oidc-secret',
+      CROWDSEC_AUTH_OIDC_SCOPE: 'openid profile email roles',
       CROWDSEC_AUTH_OIDC_GROUPS_CLAIM: 'roles',
       CROWDSEC_AUTH_OIDC_ADMIN_GROUPS: 'admins,secops',
       CROWDSEC_AUTH_OIDC_READ_ONLY_GROUPS: 'viewers',
@@ -740,6 +744,7 @@ test('dashboard auth settings use OIDC environment values as defaults', async ()
     oidcIssuerUrl: 'https://idp.example.com/application/o/crowdsec/',
     oidcClientId: 'crowdsec-client',
     hasOidcClientSecret: true,
+    oidcScope: 'openid profile email roles',
     oidcGroupsClaim: 'roles',
     oidcAdminGroups: 'admins,secops',
     oidcReadOnlyGroups: 'viewers',

--- a/server/config.test.ts
+++ b/server/config.test.ts
@@ -133,6 +133,7 @@ describe('config helpers', () => {
       CROWDSEC_AUTH_OIDC_ISSUER_URL: 'https://idp.example.com/application/o/crowdsec/',
       CROWDSEC_AUTH_OIDC_CLIENT_ID: 'crowdsec-client',
       CROWDSEC_AUTH_OIDC_CLIENT_SECRET: 'oidc-secret',
+      CROWDSEC_AUTH_OIDC_SCOPE: 'openid profile email roles',
       CROWDSEC_AUTH_OIDC_GROUPS_CLAIM: 'roles',
       CROWDSEC_AUTH_OIDC_ADMIN_GROUPS: 'admins, secops',
       CROWDSEC_AUTH_OIDC_READ_ONLY_GROUPS: 'viewers',
@@ -176,6 +177,7 @@ describe('config helpers', () => {
       oidcIssuerUrl: 'https://idp.example.com/application/o/crowdsec/',
       oidcClientId: 'crowdsec-client',
       oidcClientSecret: 'oidc-secret',
+      oidcScope: 'openid profile email roles',
       oidcGroupsClaim: 'roles',
       oidcAdminGroups: ['admins', 'secops'],
       oidcReadOnlyGroups: ['viewers'],
@@ -209,6 +211,7 @@ describe('config helpers', () => {
     expect(config.alertSyncMinChunkMs).toBe(900_000);
     expect(config.readOnly).toBe(false);
     expect(config.dashboardAuth.enabled).toBeNull();
+    expect(config.dashboardAuth.oidcScope).toBe('openid profile email groups');
     expect(config.dashboardAuth.oidcGroupsClaim).toBe('groups');
     expect(config.dashboardAuth.oidcUnmatchedRole).toBe('deny');
   });

--- a/server/config.ts
+++ b/server/config.ts
@@ -11,6 +11,7 @@ export interface DashboardAuthConfig {
   oidcIssuerUrl?: string;
   oidcClientId?: string;
   oidcClientSecret?: string;
+  oidcScope: string;
   oidcGroupsClaim: string;
   oidcAdminGroups: string[];
   oidcReadOnlyGroups: string[];
@@ -166,6 +167,7 @@ function parseDashboardAuthConfig(env: NodeJS.ProcessEnv): DashboardAuthConfig {
     oidcIssuerUrl: env.CROWDSEC_AUTH_OIDC_ISSUER_URL?.trim() || undefined,
     oidcClientId: env.CROWDSEC_AUTH_OIDC_CLIENT_ID?.trim() || undefined,
     oidcClientSecret: resolveSecretEnv('CROWDSEC_AUTH_OIDC_CLIENT_SECRET', env)?.trim() || undefined,
+    oidcScope: env.CROWDSEC_AUTH_OIDC_SCOPE?.trim() || 'openid profile email groups',
     oidcGroupsClaim: env.CROWDSEC_AUTH_OIDC_GROUPS_CLAIM?.trim() || 'groups',
     oidcAdminGroups: parseCsvEnv(env.CROWDSEC_AUTH_OIDC_ADMIN_GROUPS),
     oidcReadOnlyGroups: parseCsvEnv(env.CROWDSEC_AUTH_OIDC_READ_ONLY_GROUPS),


### PR DESCRIPTION
A lot of modern servers doesn't return groups without special scope. I personally use Pocket ID, but I know that Keycloak and Zitadel also doesn't do that by default.

This is usually required to explicitely show user that app asks for groups list access.