### PR TITLE
fix(auth): fetch OIDC UserInfo and merge claims during login

### DIFF
--- a/server/app-auth.ts
+++ b/server/app-auth.ts
@@ -184,6 +184,28 @@ export function resolveOidcRole(config: OidcRoleConfig, groups: string[]): Role 
   return config.oidcUnmatchedRole;
 }
 
+export function resolveOidcClaims(
+  idClaims: Record<string, unknown>,
+  userinfo: Record<string, unknown> | undefined,
+  config: OidcRoleConfig & { oidcGroupsClaim: string },
+): { username: string; role: Role | null } | null {
+  const merged = { ...idClaims, ...(userinfo ?? {}) };
+  const username = (
+    (typeof merged.preferred_username === 'string' && merged.preferred_username) ||
+    (typeof merged.email === 'string' && merged.email) ||
+    (typeof merged.sub === 'string' && merged.sub) ||
+    ''
+  ).trim().slice(0, 254);
+  if (!username) return null;
+
+  const groups = Array.from(new Set([
+    ...readClaimGroups(idClaims, config.oidcGroupsClaim),
+    ...readClaimGroups(userinfo ?? {}, config.oidcGroupsClaim),
+  ]));
+
+  return { username, role: resolveOidcRole(config, groups) };
+}
+
 function encryptSecret(value: string, secret: string): string {
   const key = crypto.createHash('sha256').update(secret, 'utf8').digest();
   const iv = crypto.randomBytes(12);
@@ -524,26 +546,38 @@ class OidcRuntime {
       expectedNonce,
       expectedState,
     });
-    const claims = tokens.claims() as Record<string, unknown> | undefined;
-    if (!claims) return null;
-    const issuer = typeof claims.iss === 'string' ? claims.iss : '';
-    const subject = typeof claims.sub === 'string' ? claims.sub : '';
+    const idClaims = tokens.claims() as Record<string, unknown> | undefined;
+    if (!idClaims) return null;
+    const issuer = typeof idClaims.iss === 'string' ? idClaims.iss : '';
+    const subject = typeof idClaims.sub === 'string' ? idClaims.sub : '';
     if (!issuer || !subject) return null;
 
-    const username = (
-      (typeof claims.preferred_username === 'string' && claims.preferred_username) ||
-      (typeof claims.email === 'string' && claims.email) ||
-      (typeof claims.sub === 'string' && claims.sub) ||
-      ''
-    ).trim().slice(0, 254);
-    if (!username) return null;
+    const userinfo = await this.fetchUserInfoClaims(configuration, tokens.access_token, subject);
+    const resolved = resolveOidcClaims(idClaims, userinfo, config);
+    if (!resolved) return null;
 
     return {
-      username,
-      role: resolveOidcRole(config, readClaimGroups(claims, config.oidcGroupsClaim)),
+      username: resolved.username,
+      role: resolved.role,
       issuer,
       subject,
     };
+  }
+
+  private async fetchUserInfoClaims(
+    configuration: oidcClient.Configuration,
+    accessToken: string | undefined,
+    subject: string,
+  ): Promise<Record<string, unknown> | undefined> {
+    if (!configuration.serverMetadata().userinfo_endpoint) return undefined;
+    if (typeof accessToken !== 'string' || !accessToken) return undefined;
+    try {
+      const userinfo = await oidcClient.fetchUserInfo(configuration, accessToken, subject);
+      return userinfo as Record<string, unknown>;
+    } catch (error) {
+      console.warn('OIDC UserInfo fetch failed; falling back to ID token claims:', error);
+      return undefined;
+    }
   }
 }
 

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -10,7 +10,7 @@ import { createRuntimeConfig } from './config';
 import { CrowdsecDatabase } from './database';
 import { LapiClient, type LapiRequestInit } from './lapi';
 import { createApp, type CreateAppOptions } from './app';
-import { resolveOidcRole } from './app-auth';
+import { resolveOidcClaims, resolveOidcRole } from './app-auth';
 import { resolveAlertHistoryAt } from './utils/alerts';
 import { parseGoDuration } from './utils/duration';
 import type { MqttPublishConfig } from './notifications/mqtt-client';
@@ -1153,6 +1153,63 @@ describe('OIDC role mapping', () => {
     expect(resolveOidcRole(emptyGroups, ['admins'])).toBeNull();
     expect(resolveOidcRole({ ...emptyGroups, oidcUnmatchedRole: 'admin' }, [])).toBe('admin');
     expect(resolveOidcRole({ ...emptyGroups, oidcUnmatchedRole: 'read-only' }, [])).toBe('read-only');
+  });
+});
+
+describe('resolveOidcClaims', () => {
+  const config = {
+    oidcGroupsClaim: 'https://sso.example.net/roles',
+    oidcAdminGroups: ['crowdsec-ui.crowdsec-admin'],
+    oidcReadOnlyGroups: ['crowdsec-ui.crowdsec-viewer'],
+    oidcUnmatchedRole: 'deny' as const,
+  };
+
+  test('resolves username and role from UserInfo when the ID token is minimal', () => {
+    const idClaims = { iss: 'https://sso.example.net', sub: '1' };
+    const userinfo = {
+      sub: '1',
+      email: 'admin@example.com',
+      name: 'Example Admin',
+      'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-admin'],
+    };
+    expect(resolveOidcClaims(idClaims, userinfo, config)).toEqual({
+      username: 'admin@example.com',
+      role: 'admin',
+    });
+  });
+
+  test('falls back to ID-token claims when UserInfo is absent', () => {
+    const idClaims = {
+      sub: '1',
+      preferred_username: 'id-token-user',
+      'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-viewer'],
+    };
+    expect(resolveOidcClaims(idClaims, undefined, config)).toEqual({
+      username: 'id-token-user',
+      role: 'read-only',
+    });
+  });
+
+  test('unions groups so an empty UserInfo groups value cannot erase ID-token groups', () => {
+    const idClaims = {
+      sub: '1',
+      email: 'user@example.com',
+      'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-admin'],
+    };
+    const userinfo = { sub: '1', 'https://sso.example.net/roles': [] as string[] };
+    expect(resolveOidcClaims(idClaims, userinfo, config)?.role).toBe('admin');
+  });
+
+  test('unions groups drawn from both sources', () => {
+    const idClaims = { sub: '1', email: 'user@example.com', 'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-viewer'] };
+    const userinfo = { sub: '1', 'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-admin'] };
+    // admin wins over read-only via resolveOidcRole precedence
+    expect(resolveOidcClaims(idClaims, userinfo, config)?.role).toBe('admin');
+  });
+
+  test('returns null when no username claim can be resolved', () => {
+    const idClaims = { iss: 'https://sso.example.net' };
+    expect(resolveOidcClaims(idClaims, {}, config)).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What this does

OIDC login previously derived the username and group/role membership **exclusively from the ID token**. This PR fetches the **UserInfo endpoint** after the code exchange and resolves username + groups from the **merged** claim set (ID token + UserInfo).

## Why

Per OpenID Connect Core 1.0, in the Authorization Code Flow the profile claims (`name`, `email`, `preferred_username`, …) are **not guaranteed to be in the ID token** — they are delivered from the UserInfo endpoint. `groups` is not a standard claim at all and is even less likely to appear in the ID token.

So with any provider that keeps these claims at UserInfo (the spec-default position), login degraded: the username fell back to the raw `sub`, no groups were found, and role mapping failed. The app requested `openid profile email` scopes but never called the endpoint those scopes are answered at.

### The spec basis

1. **The ID token is not where profile claims live in the code flow.** Its REQUIRED claims (§2) are `iss`, `sub`, `aud`, `exp`, `iat` — no `name`, `email`, `preferred_username`, or `groups`. A provider is fully compliant while omitting all profile claims from the ID token.

2. **Scope-requested claims are answered at UserInfo.** §5.3 defines the UserInfo endpoint as where claims about the end-user are returned using the access token. §5.4 defines what `profile`/`email` request and, for any flow that issues an access token (the code flow always does), returns them **from UserInfo**. §5.5.1 makes it explicit — requesting `email` scope is exactly `{ "userinfo": { "email": null, "email_verified": null } }`, i.e. a `userinfo` claim, not an `id_token` claim.

3. **The `claims` request parameter (§5.5) is not a reliable alternative.** It's OPTIONAL and widely unsupported — Azure AD/Entra, Okta, Auth0, and Google don't honor it, so it fails silently. Calling UserInfo is the universally-supported, canonical mechanism.


### Concrete example this fixes

**Auth0**-style: minimal ID token (essentially just `sub`), everything else at UserInfo with a namespaced roles claim:

```json
{
  "sub": "1",
  "email": "user@example.com",
  "name": "Example Admin",
  "https://sso.example.net/roles": ["crowdsec-ui.crowdsec-admin"]
}
