### PR TITLE
fix(auth): fetch OIDC UserInfo and merge claims during login

### DIFF
--- a/server/app-auth.ts
+++ b/server/app-auth.ts
@@ -184,6 +184,28 @@ export function resolveOidcRole(config: OidcRoleConfig, groups: string[]): Role 
   return config.oidcUnmatchedRole;
 }
 
+export function resolveOidcClaims(
+  idClaims: Record<string, unknown>,
+  userinfo: Record<string, unknown> | undefined,
+  config: OidcRoleConfig & { oidcGroupsClaim: string },
+): { username: string; role: Role | null } | null {
+  const merged = { ...idClaims, ...(userinfo ?? {}) };
+  const username = (
+    (typeof merged.preferred_username === 'string' && merged.preferred_username) ||
+    (typeof merged.email === 'string' && merged.email) ||
+    (typeof merged.sub === 'string' && merged.sub) ||
+    ''
+  ).trim().slice(0, 254);
+  if (!username) return null;
+
+  const groups = Array.from(new Set([
+    ...readClaimGroups(idClaims, config.oidcGroupsClaim),
+    ...readClaimGroups(userinfo ?? {}, config.oidcGroupsClaim),
+  ]));
+
+  return { username, role: resolveOidcRole(config, groups) };
+}
+
 function encryptSecret(value: string, secret: string): string {
   const key = crypto.createHash('sha256').update(secret, 'utf8').digest();
   const iv = crypto.randomBytes(12);
@@ -524,26 +546,38 @@ class OidcRuntime {
       expectedNonce,
       expectedState,
     });
-    const claims = tokens.claims() as Record<string, unknown> | undefined;
-    if (!claims) return null;
-    const issuer = typeof claims.iss === 'string' ? claims.iss : '';
-    const subject = typeof claims.sub === 'string' ? claims.sub : '';
+    const idClaims = tokens.claims() as Record<string, unknown> | undefined;
+    if (!idClaims) return null;
+    const issuer = typeof idClaims.iss === 'string' ? idClaims.iss : '';
+    const subject = typeof idClaims.sub === 'string' ? idClaims.sub : '';
     if (!issuer || !subject) return null;
 
-    const username = (
-      (typeof claims.preferred_username === 'string' && claims.preferred_username) ||
-      (typeof claims.email === 'string' && claims.email) ||
-      (typeof claims.sub === 'string' && claims.sub) ||
-      ''
-    ).trim().slice(0, 254);
-    if (!username) return null;
+    const userinfo = await this.fetchUserInfoClaims(configuration, tokens.access_token, subject);
+    const resolved = resolveOidcClaims(idClaims, userinfo, config);
+    if (!resolved) return null;
 
     return {
-      username,
-      role: resolveOidcRole(config, readClaimGroups(claims, config.oidcGroupsClaim)),
+      username: resolved.username,
+      role: resolved.role,
       issuer,
       subject,
     };
+  }
+
+  private async fetchUserInfoClaims(
+    configuration: oidcClient.Configuration,
+    accessToken: string | undefined,
+    subject: string,
+  ): Promise<Record<string, unknown> | undefined> {
+    if (!configuration.serverMetadata().userinfo_endpoint) return undefined;
+    if (typeof accessToken !== 'string' || !accessToken) return undefined;
+    try {
+      const userinfo = await oidcClient.fetchUserInfo(configuration, accessToken, subject);
+      return userinfo as Record<string, unknown>;
+    } catch (error) {
+      console.warn('OIDC UserInfo fetch failed; falling back to ID token claims:', error);
+      return undefined;
+    }
   }
 }
 

--- a/server/app.test.ts
+++ b/server/app.test.ts
@@ -10,7 +10,7 @@ import { createRuntimeConfig } from './config';
 import { CrowdsecDatabase } from './database';
 import { LapiClient, type LapiRequestInit } from './lapi';
 import { createApp, type CreateAppOptions } from './app';
-import { resolveOidcRole } from './app-auth';
+import { resolveOidcClaims, resolveOidcRole } from './app-auth';
 import { resolveAlertHistoryAt } from './utils/alerts';
 import { parseGoDuration } from './utils/duration';
 import type { MqttPublishConfig } from './notifications/mqtt-client';
@@ -1153,6 +1153,63 @@ describe('OIDC role mapping', () => {
     expect(resolveOidcRole(emptyGroups, ['admins'])).toBeNull();
     expect(resolveOidcRole({ ...emptyGroups, oidcUnmatchedRole: 'admin' }, [])).toBe('admin');
     expect(resolveOidcRole({ ...emptyGroups, oidcUnmatchedRole: 'read-only' }, [])).toBe('read-only');
+  });
+});
+
+describe('resolveOidcClaims', () => {
+  const config = {
+    oidcGroupsClaim: 'https://sso.example.net/roles',
+    oidcAdminGroups: ['crowdsec-ui.crowdsec-admin'],
+    oidcReadOnlyGroups: ['crowdsec-ui.crowdsec-viewer'],
+    oidcUnmatchedRole: 'deny' as const,
+  };
+
+  test('resolves username and role from UserInfo when the ID token is minimal', () => {
+    const idClaims = { iss: 'https://sso.example.net', sub: '1' };
+    const userinfo = {
+      sub: '1',
+      email: 'admin@example.com',
+      name: 'Example Admin',
+      'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-admin'],
+    };
+    expect(resolveOidcClaims(idClaims, userinfo, config)).toEqual({
+      username: 'admin@example.com',
+      role: 'admin',
+    });
+  });
+
+  test('falls back to ID-token claims when UserInfo is absent', () => {
+    const idClaims = {
+      sub: '1',
+      preferred_username: 'id-token-user',
+      'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-viewer'],
+    };
+    expect(resolveOidcClaims(idClaims, undefined, config)).toEqual({
+      username: 'id-token-user',
+      role: 'read-only',
+    });
+  });
+
+  test('unions groups so an empty UserInfo groups value cannot erase ID-token groups', () => {
+    const idClaims = {
+      sub: '1',
+      email: 'user@example.com',
+      'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-admin'],
+    };
+    const userinfo = { sub: '1', 'https://sso.example.net/roles': [] as string[] };
+    expect(resolveOidcClaims(idClaims, userinfo, config)?.role).toBe('admin');
+  });
+
+  test('unions groups drawn from both sources', () => {
+    const idClaims = { sub: '1', email: 'user@example.com', 'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-viewer'] };
+    const userinfo = { sub: '1', 'https://sso.example.net/roles': ['crowdsec-ui.crowdsec-admin'] };
+    // admin wins over read-only via resolveOidcRole precedence
+    expect(resolveOidcClaims(idClaims, userinfo, config)?.role).toBe('admin');
+  });
+
+  test('returns null when no username claim can be resolved', () => {
+    const idClaims = { iss: 'https://sso.example.net' };
+    expect(resolveOidcClaims(idClaims, {}, config)).toBeNull();
   });
 });
 


### PR DESCRIPTION
Read the username and group/role claims from a merge of the ID token and the UserInfo endpoint instead of the ID token alone. Per OIDC Core 1.0 (§5.3/§5.4), profile and group claims are delivered from the UserInfo endpoint in the authorization-code flow and are not guaranteed in the ID token, so providers that expose them only at UserInfo previously failed to resolve a username or role.

- Add pure, unit-tested resolveOidcClaims(): merges scalar claims and unions the configured groups claim across the ID token and UserInfo so neither source can erase the other's groups.
- handleCallback now best-effort fetches UserInfo (guarded on userinfo_endpoint and a present access token, sub-validated via fetchUserInfo's expected-subject check) and falls back to ID-token claims on any failure, so a UserInfo error never breaks login. Identity (iss/sub) stays sourced from the verified ID token.