### PR TITLE
Keep dialogs open when a press starts inside and ends on the backdrop

### DIFF
--- a/client/src/components/__tests__/Modal.test.tsx
+++ b/client/src/components/__tests__/Modal.test.tsx
@@ -1,0 +1,69 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, test, vi } from 'vitest';
+import { Modal } from '../ui/Modal';
+
+function renderModal(onClose: () => void) {
+  render(
+    <Modal isOpen onClose={onClose} title="Add Decision">
+      <input aria-label="IP Address" />
+    </Modal>,
+  );
+  return screen.getByRole('dialog').parentElement!;
+}
+
+describe('Modal', () => {
+  test('closes when the backdrop is clicked', () => {
+    const onClose = vi.fn();
+    const backdrop = renderModal(onClose);
+
+    fireEvent.pointerDown(backdrop);
+    fireEvent.click(backdrop);
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('stays open when a press starts inside the dialog and is released over the backdrop', () => {
+    const onClose = vi.fn();
+    const backdrop = renderModal(onClose);
+
+    // Selecting text in an input and releasing outside the dialog dispatches
+    // the click on the backdrop, which must not close the dialog.
+    fireEvent.pointerDown(screen.getByLabelText('IP Address'));
+    fireEvent.click(backdrop);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('closes from a later backdrop click after a press was released over the backdrop', () => {
+    const onClose = vi.fn();
+    const backdrop = renderModal(onClose);
+
+    fireEvent.pointerDown(screen.getByLabelText('IP Address'));
+    fireEvent.click(backdrop);
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.pointerDown(backdrop);
+    fireEvent.click(backdrop);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not close when clicking inside the dialog content', () => {
+    const onClose = vi.fn();
+    renderModal(onClose);
+
+    const input = screen.getByLabelText('IP Address');
+    fireEvent.pointerDown(input);
+    fireEvent.click(input);
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('closes from the close button', () => {
+    const onClose = vi.fn();
+    renderModal(onClose);
+
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/src/components/ui/Modal.tsx
+++ b/client/src/components/ui/Modal.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react';
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { createPortal } from "react-dom";
 import { X } from "lucide-react";
 
@@ -12,6 +12,11 @@ interface ModalProps extends PropsWithChildren {
 }
 
 export function Modal({ isOpen, onClose, title, children, maxWidth = "max-w-md", showCloseButton = true }: ModalProps) {
+    // Pressing inside the dialog and releasing over the backdrop (for example
+    // while selecting text in an input) dispatches the click on the backdrop,
+    // so the backdrop click only closes when the press also started on it.
+    const pressStartedOnBackdrop = useRef<boolean | null>(null);
+
     useEffect(() => {
         if (isOpen) {
             document.body.style.overflow = "hidden";
@@ -26,7 +31,17 @@ export function Modal({ isOpen, onClose, title, children, maxWidth = "max-w-md",
     if (!isOpen) return null;
 
     return createPortal(
-        <div className="fixed inset-0 z-[10000] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm" onClick={onClose}>
+        <div
+            className="fixed inset-0 z-[10000] flex items-center justify-center p-4 bg-black/50 backdrop-blur-sm"
+            onPointerDown={(event) => {
+                pressStartedOnBackdrop.current = event.target === event.currentTarget;
+            }}
+            onClick={() => {
+                const pressStartedInsideDialog = pressStartedOnBackdrop.current === false;
+                pressStartedOnBackdrop.current = null;
+                if (!pressStartedInsideDialog) onClose();
+            }}
+        >
             <div
                 className={`bg-white dark:bg-gray-800 rounded-xl shadow-2xl w-full ${maxWidth} flex flex-col max-h-[90vh]`}
                 onClick={(event) => event.stopPropagation()}


### PR DESCRIPTION
Fixes #444

Pressing the mouse down inside a dialog and releasing it outside — which is easy to do while selecting text in the IP field — makes the browser dispatch the `click` on the backdrop, so the dialog closed and threw away the input.

The shared `Modal` backdrop now records where the pointer press started (`onPointerDown`) and only closes when the press also started on the backdrop. A normal press-and-release on the backdrop still closes the dialog, and since the fix is in the shared component it applies to every dialog built on `Modal`, not just Add Decision.

#### Testing

- New `Modal.test.tsx` covering the drag-out regression (pointerdown inside, click dispatched on the backdrop, dialog must stay open) plus the existing behaviours: backdrop click closes, the close button works, clicks inside don't close, and a swallowed drag doesn't break the next backdrop click.
- Full client suite passes (359 tests), typecheck and lint are clean.
