### PR TITLE
Add an audit log for user actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Use `CONFIG_FILE` only to select another existing file. [`config.example.yaml`](
 
 - Values are parsed as YAML and validated.
 - Arrays use zero-based contiguous indexes: `CONFIG_AUTH_OIDC_ADMIN_GROUPS_0`, `CONFIG_INSTANCES_0_ID`, `CONFIG_INSTANCES_0_METRICS_0_URL`.
-- Whole sections accept YAML through `CONFIG_SERVER`, `CONFIG_STORAGE`, `CONFIG_UI`, `CONFIG_AUTH`, `CONFIG_NOTIFICATIONS`, `CONFIG_UPDATES`, `CONFIG_CROWDSEC`, or `CONFIG_INSTANCES`.
+- Whole sections accept YAML through `CONFIG_SERVER`, `CONFIG_STORAGE`, `CONFIG_UI`, `CONFIG_AUTH`, `CONFIG_NOTIFICATIONS`, `CONFIG_AUDIT`, `CONFIG_UPDATES`, `CONFIG_CROWDSEC`, or `CONFIG_INSTANCES`.
 - `CONFIG_INSTANCE_*` addresses instance `0`: `CONFIG_INSTANCE_NAME` equals `CONFIG_INSTANCES_0_NAME`. Metrics index `0` may also be omitted: `CONFIG_INSTANCES_0_METRICS_URL` equals `CONFIG_INSTANCES_0_METRICS_0_URL`, and `CONFIG_INSTANCE_METRICS_URL` applies both shorthands. Do not set equivalent forms together.
 - Secrets accept a direct string or exactly one `env: NAME` / `file: PATH` reference. Secret overrides also accept `_FILE`.
 - Initial direct secret overrides are stored as environment references, never plaintext. Persisted secret references still require their environment variable.
@@ -246,6 +246,19 @@ Use `CONFIG_FILE` only to select another existing file. [`config.example.yaml`](
 | `notifications.secretKey` | Generated and stored | Encrypts saved notification credentials. | `CONFIG_NOTIFICATIONS_SECRET_KEY` or `CONFIG_NOTIFICATIONS_SECRET_KEY_FILE` |
 | `notifications.allowPrivateAddresses` | `true` | Allows private, loopback, and link-local notification destinations. | `CONFIG_NOTIFICATIONS_ALLOW_PRIVATE_ADDRESSES` |
 | `notifications.debugPayloads` | `false` | Logs truncated rendered payloads after failed notification delivery. | `CONFIG_NOTIFICATIONS_DEBUG_PAYLOADS` |
+
+### Audit log
+
+User actions that change CrowdSec state (adding decisions, deleting decisions and alerts, and per-IP cleanup) are recorded as single `[audit]` lines in the application log. Each entry is a JSON object with the timestamp, acting user and role, action, target (IP, range, or entity IDs), and outcome:
+
+```
+[audit] {"time":"2026-08-17T01:30:00.000Z","user":"tommy","role":"admin","action":"decision.add","ip":"192.0.2.10","type":"ban","duration":"4h","reason":"manual","instances":["CrowdSec"],"outcome":"success"}
+```
+
+| YAML field | Default | Purpose | Environment override |
+| --- | --- | --- | --- |
+| `audit.enabled` | `true` | Writes audit entries for user actions to the application log. | `CONFIG_AUDIT_ENABLED` |
+| `audit.logFile` | Unset | Also appends audit entries as JSON lines to this file. | `CONFIG_AUDIT_LOG_FILE` |
 
 ### Alert handling
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -56,6 +56,13 @@
 #   allowPrivateAddresses: true
 #   debugPayloads: false
 
+# audit:
+#   enabled: true
+#   Audit entries describe user actions (added and removed decisions and
+#   alerts) as single JSON lines in the application log. Set logFile to also
+#   append them to a dedicated file.
+#   logFile: /app/data/audit.log
+
 # crowdsec:
 #   simulationsEnabled: false
 #   Uncomment alertFilters to override the default non-CAPI feed.

--- a/server/__tests__/app/audit-log.test.ts
+++ b/server/__tests__/app/audit-log.test.ts
@@ -1,0 +1,261 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, test, vi, type MockInstance } from 'vitest';
+import {
+  createController,
+  destroyTempDir,
+  sampleAlert,
+  seedAlert,
+  tempDir,
+} from './harness';
+
+function auditEntries(logSpy: MockInstance): Array<Record<string, unknown>> {
+  return logSpy.mock.calls
+    .map((call) => String(call[0]))
+    .filter((line) => line.startsWith('[audit] '))
+    .map((line) => JSON.parse(line.slice('[audit] '.length)) as Record<string, unknown>);
+}
+
+describe('audit log', () => {
+  test('records added decisions with the authenticated user', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { controller, database, lapiClient } = createController({
+      env: { AUTH_ENABLED: 'true' },
+      initialCacheState: { isInitialized: true, isComplete: true, lastUpdate: new Date().toISOString() },
+    });
+    try {
+      const setupResponse = await controller.fetch(new Request('http://localhost/crowdsec/api/auth/setup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username: 'tommy', password: 'Password1' }),
+      }));
+      expect(setupResponse.status).toBe(200);
+      const sessionCookie = String(setupResponse.headers.get('set-cookie')).split(';')[0];
+
+      await lapiClient.login();
+      const response = await controller.fetch(new Request('http://localhost/crowdsec/api/decisions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Cookie: sessionCookie },
+        body: JSON.stringify({ ip: '5.6.7.8', duration: '4h', type: 'ban', reason: 'manual' }),
+      }));
+      expect(response.status).toBe(200);
+
+      expect(auditEntries(logSpy)).toEqual([expect.objectContaining({
+        time: expect.any(String),
+        user: 'tommy',
+        role: 'admin',
+        action: 'decision.add',
+        ip: '5.6.7.8',
+        type: 'ban',
+        duration: '4h',
+        reason: 'manual',
+        instances: ['CrowdSec'],
+        outcome: 'success',
+      })]);
+    } finally {
+      controller.stopBackgroundTasks();
+      database.close();
+      logSpy.mockRestore();
+      destroyTempDir();
+    }
+  });
+
+  test('records single decision deletions with the banned value from the cache', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { controller, database, lapiClient } = createController();
+    try {
+      seedAlert(database, sampleAlert());
+      await lapiClient.login();
+
+      const response = await controller.fetch(new Request('http://localhost/crowdsec/api/decisions/10', {
+        method: 'DELETE',
+      }));
+      expect(response.status).toBe(200);
+
+      expect(auditEntries(logSpy)).toEqual([expect.objectContaining({
+        user: 'disabled-auth',
+        action: 'decision.delete',
+        decision_ids: ['10'],
+        values: ['1.2.3.4'],
+        outcome: 'success',
+      })]);
+    } finally {
+      controller.stopBackgroundTasks();
+      database.close();
+      logSpy.mockRestore();
+      destroyTempDir();
+    }
+  });
+
+  test('records bulk decision deletions with resolved values and counters', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { controller, database, lapiClient } = createController();
+    try {
+      seedAlert(database, sampleAlert());
+      await lapiClient.login();
+
+      const response = await controller.fetch(new Request('http://localhost/crowdsec/api/decisions/bulk-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ids: ['10'] }),
+      }));
+      expect(response.status).toBe(200);
+
+      expect(auditEntries(logSpy)).toEqual([expect.objectContaining({
+        action: 'decision.delete',
+        decision_ids: ['10'],
+        values: ['1.2.3.4'],
+        requested_decisions: 1,
+        deleted_decisions: 1,
+        outcome: 'success',
+      })]);
+    } finally {
+      controller.stopBackgroundTasks();
+      database.close();
+      logSpy.mockRestore();
+      destroyTempDir();
+    }
+  });
+
+  test('records alert deletions with the deleted entity counters', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { controller, database, lapiClient } = createController();
+    try {
+      seedAlert(database, sampleAlert());
+      await lapiClient.login();
+
+      const response = await controller.fetch(new Request('http://localhost/crowdsec/api/alerts/1', {
+        method: 'DELETE',
+      }));
+      expect(response.status).toBe(200);
+
+      expect(auditEntries(logSpy)).toEqual([expect.objectContaining({
+        action: 'alert.delete',
+        alert_ids: ['1'],
+        deleted_alerts: 1,
+        deleted_decisions: 1,
+        outcome: 'success',
+      })]);
+    } finally {
+      controller.stopBackgroundTasks();
+      database.close();
+      logSpy.mockRestore();
+      destroyTempDir();
+    }
+  });
+
+  test('records bulk alert deletions requested through instance refs', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { controller, database, lapiClient } = createController();
+    try {
+      seedAlert(database, sampleAlert());
+      await lapiClient.login();
+
+      const response = await controller.fetch(new Request('http://localhost/crowdsec/api/alerts/bulk-delete', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ refs: [{ instance_id: 'default', id: '1' }] }),
+      }));
+      expect(response.status).toBe(200);
+
+      expect(auditEntries(logSpy)).toEqual([expect.objectContaining({
+        action: 'alert.delete',
+        alert_ids: ['default:1'],
+        requested_alerts: 1,
+        deleted_alerts: 1,
+        outcome: 'success',
+      })]);
+    } finally {
+      controller.stopBackgroundTasks();
+      database.close();
+      logSpy.mockRestore();
+      destroyTempDir();
+    }
+  });
+
+  test('records per-IP cleanups with the deleted entity counters', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { controller, database, lapiClient } = createController();
+    try {
+      seedAlert(database, sampleAlert());
+      await lapiClient.login();
+
+      const response = await controller.fetch(new Request('http://localhost/crowdsec/api/cleanup/by-ip', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ip: '1.2.3.4' }),
+      }));
+      expect(response.status).toBe(200);
+
+      expect(auditEntries(logSpy)).toEqual([expect.objectContaining({
+        action: 'cleanup.by-ip',
+        ip: '1.2.3.4',
+        instances: ['CrowdSec'],
+        deleted_alerts: 1,
+        deleted_decisions: 1,
+        outcome: 'success',
+      })]);
+    } finally {
+      controller.stopBackgroundTasks();
+      database.close();
+      logSpy.mockRestore();
+      destroyTempDir();
+    }
+  });
+
+  test('stays silent when audit logging is disabled', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const { controller, database, lapiClient } = createController({
+      env: { CONFIG_AUDIT_ENABLED: 'false' },
+      initialCacheState: { isInitialized: true, isComplete: true, lastUpdate: new Date().toISOString() },
+    });
+    try {
+      await lapiClient.login();
+      const response = await controller.fetch(new Request('http://localhost/crowdsec/api/decisions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ip: '5.6.7.8', duration: '4h', type: 'ban', reason: 'manual' }),
+      }));
+      expect(response.status).toBe(200);
+
+      expect(auditEntries(logSpy)).toEqual([]);
+    } finally {
+      controller.stopBackgroundTasks();
+      database.close();
+      logSpy.mockRestore();
+      destroyTempDir();
+    }
+  });
+
+  test('appends audit entries to the configured log file', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const logFile = path.join(tempDir, 'logs', 'audit.log');
+    const { controller, database, lapiClient } = createController({
+      env: { CONFIG_AUDIT_LOG_FILE: logFile },
+      initialCacheState: { isInitialized: true, isComplete: true, lastUpdate: new Date().toISOString() },
+    });
+    try {
+      await lapiClient.login();
+      const response = await controller.fetch(new Request('http://localhost/crowdsec/api/decisions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ip: '5.6.7.8', duration: '4h', type: 'ban', reason: 'manual' }),
+      }));
+      expect(response.status).toBe(200);
+
+      const lines = readFileSync(logFile, 'utf8').trimEnd().split('\n');
+      expect(lines).toHaveLength(1);
+      expect(JSON.parse(lines[0])).toEqual(expect.objectContaining({
+        user: 'disabled-auth',
+        action: 'decision.add',
+        ip: '5.6.7.8',
+        outcome: 'success',
+      }));
+    } finally {
+      controller.stopBackgroundTasks();
+      database.close();
+      logSpy.mockRestore();
+      destroyTempDir();
+    }
+  });
+});

--- a/server/__tests__/config/files.test.ts
+++ b/server/__tests__/config/files.test.ts
@@ -40,6 +40,9 @@ notifications:
     env: YAML_NOTIFICATION_KEY
   allowPrivateAddresses: false
   debugPayloads: true
+audit:
+  enabled: false
+  logFile: /var/log/crowdsec-web-ui/audit.log
 updates:
   enabled: false
 crowdsec:
@@ -113,6 +116,8 @@ instances:
         notificationSecretKey: 'notification-secret',
         notificationAllowPrivateAddresses: false,
         notificationDebugPayloads: true,
+        auditEnabled: false,
+        auditLogFile: '/var/log/crowdsec-web-ui/audit.log',
         updateCheckEnabled: false,
       });
       expect(config.dashboardAuth.sessionSecret).toBe('auth-secret');
@@ -416,6 +421,64 @@ instances:
     const persisted = parseYaml(readFileSync(generatedConfigFile, 'utf8'));
     expect(persisted.instances[0].lapi.auth.type).toBeUndefined();
     expect(persisted.instances[0].metrics[0].auth.type).toBeUndefined();
+  });
+
+  test('keeps audit logging enabled without a file by default', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const config = createRuntimeConfig({});
+      expect(config.auditEnabled).toBe(true);
+      expect(config.auditLogFile).toBeUndefined();
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test('treats an empty audit logFile as unset', () => {
+    const configFile = createTempConfig(`
+audit:
+  logFile: ""
+instances:
+  - id: default
+    name: CrowdSec
+    lapi:
+      url: http://crowdsec:8080
+      auth: { type: none }
+`);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const config = createRuntimeConfig({ CONFIG_FILE: configFile });
+      expect(config.auditEnabled).toBe(true);
+      expect(config.auditLogFile).toBeUndefined();
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test('rejects invalid audit settings', () => {
+    const invalidEnabled = createTempConfig(`
+audit:
+  enabled: please
+instances:
+  - id: default
+    name: CrowdSec
+    lapi:
+      url: http://crowdsec:8080
+      auth: { type: none }
+`);
+    expect(() => createRuntimeConfig({ CONFIG_FILE: invalidEnabled })).toThrow(/audit\.enabled must be a boolean/i);
+
+    const unknownKey = createTempConfig(`
+audit:
+  file: /var/log/audit.log
+instances:
+  - id: default
+    name: CrowdSec
+    lapi:
+      url: http://crowdsec:8080
+      auth: { type: none }
+`);
+    expect(() => createRuntimeConfig({ CONFIG_FILE: unknownKey })).toThrow(/unknown audit setting.*file/i);
   });
 
   test('prefers CONFIG_ setup values over deprecated values during initial generation', () => {

--- a/server/__tests__/config/overrides.test.ts
+++ b/server/__tests__/config/overrides.test.ts
@@ -29,6 +29,26 @@ describe('configuration overrides', () => {
     }
   });
 
+  test('applies CONFIG_AUDIT_ overrides', () => {
+    const generatedConfigFile = createMissingConfigPath();
+    createRuntimeConfigImpl({}, { defaultConfigFile: generatedConfigFile });
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const config = createRuntimeConfigImpl({
+        CONFIG_AUDIT_ENABLED: 'false',
+        CONFIG_AUDIT_LOG_FILE: '/var/log/crowdsec-web-ui/audit.log',
+      }, { defaultConfigFile: generatedConfigFile });
+      expect(config.auditEnabled).toBe(false);
+      expect(config.auditLogFile).toBe('/var/log/crowdsec-web-ui/audit.log');
+      expect(log).toHaveBeenCalledWith('  CONFIG_AUDIT_ENABLED -> audit.enabled: <unset> -> false');
+      expect(log).toHaveBeenCalledWith(
+        '  CONFIG_AUDIT_LOG_FILE -> audit.logFile: <unset> -> "/var/log/crowdsec-web-ui/audit.log"',
+      );
+    } finally {
+      log.mockRestore();
+    }
+  });
+
   test('persists CONFIG_ values to an existing YAML when explicitly enabled', () => {
     const generatedConfigFile = createMissingConfigPath();
     createRuntimeConfigImpl({ CONFIG_SERVER_PORT: '4100' }, { defaultConfigFile: generatedConfigFile });

--- a/server/__tests__/logging/audit-log.test.ts
+++ b/server/__tests__/logging/audit-log.test.ts
@@ -1,0 +1,133 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { createAuditLogger, type AuditActor } from '../../audit-log';
+
+const tempDirs: string[] = [];
+
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'crowdsec-web-ui-audit-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function createLogger(options: { enabled?: boolean; logFile?: string; actor?: AuditActor | null } = {}) {
+  return createAuditLogger({
+    enabled: options.enabled ?? true,
+    logFile: options.logFile,
+    getActor: () => (options.actor === undefined ? { username: 'tommy', role: 'admin' } : options.actor),
+  });
+}
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('createAuditLogger', () => {
+  test('writes a structured console line and appends the entry to the log file', () => {
+    const logFile = join(createTempDir(), 'logs', 'audit.log');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const auditLog = createLogger({ logFile });
+      auditLog.record({}, { action: 'decision.add', ip: '1.2.3.4', type: 'ban', outcome: 'success' });
+
+      expect(log).toHaveBeenCalledTimes(1);
+      const line = String(log.mock.calls[0][0]);
+      expect(line.startsWith('[audit] ')).toBe(true);
+      const entry = JSON.parse(line.slice('[audit] '.length));
+      expect(entry).toMatchObject({
+        user: 'tommy',
+        role: 'admin',
+        action: 'decision.add',
+        ip: '1.2.3.4',
+        type: 'ban',
+        outcome: 'success',
+      });
+      expect(Number.isNaN(Date.parse(entry.time))).toBe(false);
+      expect(readFileSync(logFile, 'utf8')).toBe(`${line.slice('[audit] '.length)}\n`);
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test('appends one line per recorded entry', () => {
+    const logFile = join(createTempDir(), 'audit.log');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const auditLog = createLogger({ logFile });
+      auditLog.record({}, { action: 'decision.add', ip: '1.2.3.4', outcome: 'success' });
+      auditLog.record({}, { action: 'decision.delete', decision_ids: ['10'], outcome: 'success' });
+
+      const lines = readFileSync(logFile, 'utf8').trimEnd().split('\n');
+      expect(lines).toHaveLength(2);
+      expect(JSON.parse(lines[0]).action).toBe('decision.add');
+      expect(JSON.parse(lines[1]).action).toBe('decision.delete');
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test('stays silent when disabled', () => {
+    const logFile = join(createTempDir(), 'audit.log');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const auditLog = createLogger({ enabled: false, logFile });
+      auditLog.record({}, { action: 'decision.add', ip: '1.2.3.4', outcome: 'success' });
+
+      expect(log).not.toHaveBeenCalled();
+      expect(() => readFileSync(logFile, 'utf8')).toThrow();
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test('records unknown when no actor is available', () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    try {
+      const auditLog = createLogger({ actor: null });
+      auditLog.record({}, { action: 'alert.delete', alert_ids: ['1'], outcome: 'success' });
+
+      const entry = JSON.parse(String(log.mock.calls[0][0]).slice('[audit] '.length));
+      expect(entry.user).toBe('unknown');
+      expect(entry.role).toBeUndefined();
+    } finally {
+      log.mockRestore();
+    }
+  });
+
+  test('keeps console logging when the log file cannot be written', () => {
+    const logFile = join(createTempDir(), 'audit.log');
+    mkdirSync(logFile);
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const auditLog = createLogger({ logFile });
+      auditLog.record({}, { action: 'decision.add', ip: '1.2.3.4', outcome: 'success' });
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('[audit] '));
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('Failed to write audit log entry'));
+    } finally {
+      error.mockRestore();
+      log.mockRestore();
+    }
+  });
+
+  test('warns once when the log file directory cannot be created', () => {
+    const blockingFile = join(createTempDir(), 'not-a-directory');
+    writeFileSync(blockingFile, 'occupied', 'utf8');
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const auditLog = createLogger({ logFile: join(blockingFile, 'audit.log') });
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('could not be created'));
+
+      auditLog.record({}, { action: 'decision.add', ip: '1.2.3.4', outcome: 'success' });
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('[audit] '));
+      expect(error).toHaveBeenCalledTimes(1);
+    } finally {
+      error.mockRestore();
+      log.mockRestore();
+    }
+  });
+});

--- a/server/app.ts
+++ b/server/app.ts
@@ -41,6 +41,7 @@ import {
 } from './normalized-record';
 import { LapiClient } from './lapi';
 import { createDashboardAuth } from './app-auth';
+import { createAuditLogger } from './audit-log';
 import { createNotificationService } from './notifications';
 import type { MqttPublishConfig } from './notifications/mqtt-client';
 import { createNotificationOutboundGuard } from './notifications/outbound-guard';
@@ -469,6 +470,11 @@ export function createApp(options: CreateAppOptions = {}): AppController {
     instanceReadOnly: config.readOnly,
     writeDatabase: (operation) => syncWorker.runExclusive(operation),
   });
+  const auditLog = createAuditLogger({
+    enabled: config.auditEnabled,
+    logFile: config.auditLogFile,
+    getActor: (context) => dashboardAuth.getSession(context),
+  });
 
   const app = new Hono();
   const distRoot = options.distRoot || path.resolve(process.cwd(), 'dist/client');
@@ -823,6 +829,7 @@ export function createApp(options: CreateAppOptions = {}): AppController {
   Dashboard Auth: ${dashboardAuth.enabled ? 'Enabled' : 'Disabled'}
   Dashboard OIDC: ${dashboardAuth.oidcEnabled ? 'Enabled' : 'Disabled'}
   Read-only Mode: ${config.readOnly ? 'Enabled' : 'Disabled'}
+  Audit Log: ${config.auditEnabled ? `Enabled${config.auditLogFile ? ` (file: ${config.auditLogFile})` : ''}` : 'Disabled'}
 `);
 
   if (!lapiClient.hasAuthConfig()) {
@@ -1251,6 +1258,7 @@ export function createApp(options: CreateAppOptions = {}): AppController {
     aggregateHistoricalSyncStatus,
     aggregateLapiStatus,
     applySimulationModeToAlert,
+    auditLog,
     buildDashboardStats,
     checkForUpdates,
     compileAlertSearch,

--- a/server/app/api-routes.ts
+++ b/server/app/api-routes.ts
@@ -15,6 +15,7 @@ import type {
   UpsertNotificationChannelRequest,
   UpsertNotificationRuleRequest,
 } from '../../shared/contracts';
+import type { AuditOutcome } from '../audit-log';
 import type { RuntimeConfig } from '../config';
 import type { CrowdsecDatabase } from '../database';
 import type { LapiClient } from '../lapi';
@@ -69,6 +70,7 @@ export function registerApiRoutes(dependencies: ApiRouteDependencies): void {
     aggregateHistoricalSyncStatus,
     aggregateLapiStatus,
     applySimulationModeToAlert,
+    auditLog,
     buildDashboardStats,
     checkForUpdates,
     compileAlertSearch,
@@ -161,6 +163,33 @@ export function registerApiRoutes(dependencies: ApiRouteDependencies): void {
     withInstanceName,
     decisionFromRow,
   } = dependencies;
+
+  // Audit lists stay bounded so a large bulk operation cannot produce an
+  // unusable log line; the requested/deleted counters remain exact.
+  const AUDIT_LIST_LIMIT = 100;
+
+  function capAuditEntries(entries: string[]): { entries: string[]; truncated: boolean } {
+    return entries.length > AUDIT_LIST_LIMIT
+      ? { entries: entries.slice(0, AUDIT_LIST_LIMIT), truncated: true }
+      : { entries, truncated: false };
+  }
+
+  function auditOutcome(succeeded: number, failed: number): AuditOutcome {
+    if (failed === 0) return 'success';
+    return succeeded > 0 ? 'partial' : 'failure';
+  }
+
+  // Deletions are requested by decision ID, so the banned value (IP or range)
+  // is resolved from the local cache while the rows still exist.
+  function resolveDecisionValues(refs: Array<{ id: string | number; instance_id?: string }>): string[] {
+    const values = new Set<string>();
+    for (const ref of refs) {
+      const internalId = ref.instance_id ? database.getDecisionInternalId(ref.instance_id, ref.id) : String(ref.id);
+      const value = internalId === null ? undefined : database.getDecisionById(internalId)?.value;
+      if (typeof value === 'string' && value) values.add(value);
+    }
+    return Array.from(values);
+  }
 
 app.get(`${config.basePath}/api/alerts`, ensureAuth, ensurePublishedRevisionRead, async (context) => {
   try {
@@ -264,6 +293,15 @@ app.post(`${config.basePath}/api/alerts/bulk-delete`, ensureAuth, async (context
         }
       }));
       invalidateDashboardStatsCache();
+      const alertIds = capAuditEntries(validated.map((ref: InstanceEntityRef) => `${ref.instance_id}:${ref.id}`));
+      auditLog.record(context, {
+        action: 'alert.delete',
+        alert_ids: alertIds.entries,
+        ...(alertIds.truncated ? { truncated: true } : {}),
+        requested_alerts: result.requested_alerts,
+        deleted_alerts: result.deleted_alerts,
+        outcome: auditOutcome(result.deleted_alerts, result.failed.length),
+      });
       return context.json(result);
     }
     if (!Array.isArray(body.ids) || body.ids.length === 0) {
@@ -278,6 +316,15 @@ app.post(`${config.basePath}/api/alerts/bulk-delete`, ensureAuth, async (context
     }
 
     const result = await deleteAlertsByIds(ids);
+    const alertIds = capAuditEntries(ids);
+    auditLog.record(context, {
+      action: 'alert.delete',
+      alert_ids: alertIds.entries,
+      ...(alertIds.truncated ? { truncated: true } : {}),
+      deleted_alerts: result.deleted_alerts,
+      deleted_decisions: result.deleted_decisions,
+      outcome: auditOutcome(result.deleted_alerts + result.deleted_decisions, result.failed.length),
+    });
     if (result.deleted_decisions > 0) {
       void runNotificationEvaluation('bulk alert delete');
     }
@@ -344,6 +391,13 @@ app.delete(`${config.basePath}/api/alerts/:id`, ensureAuth, async (context) => {
 
   const doRequest = async () => {
     const result = await deleteAlertsByIds([alertId]);
+    auditLog.record(context, {
+      action: 'alert.delete',
+      alert_ids: [alertId],
+      deleted_alerts: result.deleted_alerts,
+      deleted_decisions: result.deleted_decisions,
+      outcome: auditOutcome(result.deleted_alerts + result.deleted_decisions, result.failed.length),
+    });
     if (result.deleted_decisions > 0) {
       void runNotificationEvaluation('alert decision delete');
     }
@@ -465,9 +519,16 @@ app.delete(`${config.basePath}/api/instances/:instanceId/alerts/:id`, ensureAuth
   const instance = config.instances.find((candidate) => candidate.id === instanceId);
   if (!instance) return context.json({ error: 'Unknown CrowdSec instance' }, 404);
   try {
-    await lapiClients.get(instanceId)!.deleteAlert(context.req.param('id'));
-    await syncWorker.runExclusive(() => database.deleteAlertByInstanceId(instanceId, context.req.param('id')));
+    const alertId = String(context.req.param('id'));
+    await lapiClients.get(instanceId)!.deleteAlert(alertId);
+    await syncWorker.runExclusive(() => database.deleteAlertByInstanceId(instanceId, alertId));
     invalidateDashboardStatsCache();
+    auditLog.record(context, {
+      action: 'alert.delete',
+      alert_ids: [alertId],
+      instance: instance.name,
+      outcome: 'success',
+    });
     return context.json({
       requested_alerts: 1,
       requested_decisions: 0,
@@ -487,9 +548,18 @@ app.delete(`${config.basePath}/api/instances/:instanceId/decisions/:id`, ensureA
   const instance = config.instances.find((candidate) => candidate.id === instanceId);
   if (!instance) return context.json({ error: 'Unknown CrowdSec instance' }, 404);
   try {
-    await lapiClients.get(instanceId)!.deleteDecision(context.req.param('id'));
-    await syncWorker.runExclusive(() => database.deleteDecisionByInstanceId(instanceId, context.req.param('id')));
+    const decisionId = String(context.req.param('id'));
+    const values = resolveDecisionValues([{ id: decisionId, instance_id: instanceId }]);
+    await lapiClients.get(instanceId)!.deleteDecision(decisionId);
+    await syncWorker.runExclusive(() => database.deleteDecisionByInstanceId(instanceId, decisionId));
     invalidateDashboardStatsCache();
+    auditLog.record(context, {
+      action: 'decision.delete',
+      decision_ids: [decisionId],
+      ...(values.length > 0 ? { values } : {}),
+      instance: instance.name,
+      outcome: 'success',
+    });
     return context.json({ message: 'Deleted' });
   } catch (error: any) {
     return context.json({ error: error?.message || 'Failed to delete decision' }, 502);
@@ -765,6 +835,14 @@ app.post(`${config.basePath}/api/cleanup/by-ip`, ensureAuth, async (context) => 
     }));
     const succeeded = results.filter((result) => result.success).length;
     const payload = { results, succeeded, failed: results.length - succeeded };
+    auditLog.record(context, {
+      action: 'cleanup.by-ip',
+      ip,
+      instances: results.map((result) => result.instance_name),
+      deleted_alerts: results.reduce((total, entry) => total + ('result' in entry && entry.result ? entry.result.deleted_alerts : 0), 0),
+      deleted_decisions: results.reduce((total, entry) => total + ('result' in entry && entry.result ? entry.result.deleted_decisions : 0), 0),
+      outcome: auditOutcome(succeeded, results.length - succeeded),
+    });
     if (succeeded > 0) void runNotificationEvaluation('cleanup by ip');
     if (results.length === 1 && body.scope === undefined && results[0].success && 'result' in results[0]) {
       return context.json(results[0].result);
@@ -1130,6 +1208,15 @@ app.post(`${config.basePath}/api/decisions`, ensureAuth, async (context) => {
     for (const result of results) {
       if (result.success) console.log(`[decisions] Added ${type} decision for ${ip} (${duration}). Instance: ${result.instance_name}.`);
     }
+    auditLog.record(context, {
+      action: 'decision.add',
+      ip,
+      type,
+      duration,
+      reason: reason.slice(0, 256),
+      instances: results.map((result) => result.instance_name),
+      outcome: auditOutcome(succeeded, results.length - succeeded),
+    });
     if (succeeded > 0) void runNotificationEvaluation('manual decision add');
     if (results.length === 1 && body.scope === undefined && results[0].success) {
       return context.json({ message: 'Decision added (via Alert)', result: results[0].result });
@@ -1153,6 +1240,7 @@ app.post(`${config.basePath}/api/decisions/bulk-delete`, ensureAuth, async (cont
     if (Array.isArray(body.refs) && body.refs.length > 0) {
       const validated = validateInstanceEntityRefs(body.refs);
       if ('error' in validated) return context.json({ error: validated.error }, 400);
+      const auditValues = capAuditEntries(resolveDecisionValues(validated));
       const result = createDeleteResult({ requested_decisions: validated.length });
       const groups = groupInstanceEntityRefs(validated);
       await Promise.all(Array.from(groups, async ([instanceId, ids]) => {
@@ -1169,6 +1257,16 @@ app.post(`${config.basePath}/api/decisions/bulk-delete`, ensureAuth, async (cont
       }));
       await syncWorker.runExclusive(() => database.refreshDecisionDuplicateFlags(new Date().toISOString()));
       invalidateDashboardStatsCache();
+      const decisionIds = capAuditEntries(validated.map((ref: InstanceEntityRef) => `${ref.instance_id}:${ref.id}`));
+      auditLog.record(context, {
+        action: 'decision.delete',
+        decision_ids: decisionIds.entries,
+        ...(auditValues.entries.length > 0 ? { values: auditValues.entries } : {}),
+        ...(decisionIds.truncated || auditValues.truncated ? { truncated: true } : {}),
+        requested_decisions: result.requested_decisions,
+        deleted_decisions: result.deleted_decisions,
+        outcome: auditOutcome(result.deleted_decisions, result.failed.length),
+      });
       if (result.deleted_decisions > 0) void runNotificationEvaluation('bulk decision delete');
       return context.json(result);
     }
@@ -1183,7 +1281,18 @@ app.post(`${config.basePath}/api/decisions/bulk-delete`, ensureAuth, async (cont
       return context.json({ error: 'Decision IDs must be numeric' }, 400);
     }
 
+    const auditValues = capAuditEntries(resolveDecisionValues(ids.map((id: string) => ({ id }))));
     const result = await deleteDecisionsByIdsInChunks(ids);
+    const decisionIds = capAuditEntries(ids);
+    auditLog.record(context, {
+      action: 'decision.delete',
+      decision_ids: decisionIds.entries,
+      ...(auditValues.entries.length > 0 ? { values: auditValues.entries } : {}),
+      ...(decisionIds.truncated || auditValues.truncated ? { truncated: true } : {}),
+      requested_decisions: result.requested_decisions,
+      deleted_decisions: result.deleted_decisions,
+      outcome: auditOutcome(result.deleted_decisions, result.failed.length),
+    });
     if (result.deleted_decisions > 0) {
       void runNotificationEvaluation('bulk decision delete');
     }
@@ -1208,6 +1317,7 @@ app.delete(`${config.basePath}/api/decisions/:id`, ensureAuth, async (context) =
   }
 
   const doRequest = async () => {
+    const values = resolveDecisionValues([{ id: decisionId }]);
     const result = await deleteDecisionFromLapi(decisionId);
     console.log(`Removing decision ${decisionId} from local cache...`);
     await syncWorker.runExclusive(() => {
@@ -1215,6 +1325,12 @@ app.delete(`${config.basePath}/api/decisions/:id`, ensureAuth, async (context) =
       database.refreshDecisionDuplicateFlags(new Date().toISOString());
     });
     invalidateDashboardStatsCache();
+    auditLog.record(context, {
+      action: 'decision.delete',
+      decision_ids: [decisionId],
+      ...(values.length > 0 ? { values } : {}),
+      outcome: 'success',
+    });
     void runNotificationEvaluation('decision delete');
     return context.json((result as object) || { message: 'Deleted' });
   };

--- a/server/audit-log.ts
+++ b/server/audit-log.ts
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+type HonoContext = any;
+
+export type AuditAction = 'decision.add' | 'decision.delete' | 'alert.delete' | 'cleanup.by-ip';
+export type AuditOutcome = 'success' | 'partial' | 'failure';
+
+export interface AuditActor {
+  username: string;
+  role?: string;
+}
+
+export interface AuditEvent {
+  action: AuditAction;
+  outcome: AuditOutcome;
+  [detail: string]: unknown;
+}
+
+export interface AuditLogger {
+  enabled: boolean;
+  record: (context: HonoContext, event: AuditEvent) => void;
+}
+
+export interface CreateAuditLoggerOptions {
+  enabled: boolean;
+  logFile?: string;
+  getActor: (context: HonoContext) => AuditActor | null;
+}
+
+export function createAuditLogger(options: CreateAuditLoggerOptions): AuditLogger {
+  const { enabled, logFile, getActor } = options;
+  let fileWritable = Boolean(logFile);
+
+  if (enabled && logFile) {
+    try {
+      fs.mkdirSync(path.dirname(logFile), { recursive: true });
+    } catch (error) {
+      fileWritable = false;
+      console.error(`Audit log file directory for "${logFile}" could not be created: ${(error as Error).message}`);
+    }
+  }
+
+  function record(context: HonoContext, event: AuditEvent): void {
+    if (!enabled) return;
+
+    // Audit logging must never break the user action it describes.
+    try {
+      const actor = getActor(context);
+      const line = JSON.stringify({
+        time: new Date().toISOString(),
+        user: actor?.username || 'unknown',
+        ...(actor?.role ? { role: actor.role } : {}),
+        ...event,
+      });
+      console.log(`[audit] ${line}`);
+      if (logFile && fileWritable) {
+        fs.appendFileSync(logFile, `${line}\n`, 'utf8');
+      }
+    } catch (error) {
+      console.error(`Failed to write audit log entry: ${(error as Error).message}`);
+    }
+  }
+
+  return { enabled, record };
+}

--- a/server/config-file.ts
+++ b/server/config-file.ts
@@ -154,7 +154,7 @@ function applySecretReference(
 
 export function parseApplicationConfig(parsed: unknown, sourceEnv: NodeJS.ProcessEnv): ParsedConfigFile {
   const root = record(parsed, 'config');
-  knownKeys(root, ['server', 'storage', 'ui', 'auth', 'notifications', 'updates', 'crowdsec', 'instances'], 'root');
+  knownKeys(root, ['server', 'storage', 'ui', 'auth', 'notifications', 'audit', 'updates', 'crowdsec', 'instances'], 'root');
 
   const env: NodeJS.ProcessEnv = {};
   for (const name of RETAINED_METADATA_ENV) {
@@ -204,6 +204,11 @@ export function parseApplicationConfig(parsed: unknown, sourceEnv: NodeJS.Proces
   applySecretReference(notifications.secretKey, 'notifications.secretKey', env, sourceEnv, 'NOTIFICATION_SECRET_KEY');
   setBoolean(env, notifications, 'allowPrivateAddresses', 'NOTIFICATION_ALLOW_PRIVATE_ADDRESSES', 'notifications');
   setBoolean(env, notifications, 'debugPayloads', 'NOTIFICATION_DEBUG_PAYLOADS', 'notifications');
+
+  const audit = section(root, 'audit');
+  knownKeys(audit, ['enabled', 'logFile'], 'audit');
+  setBoolean(env, audit, 'enabled', 'AUDIT_ENABLED', 'audit');
+  setString(env, audit, 'logFile', 'AUDIT_LOG_FILE', 'audit', true);
 
   const updates = section(root, 'updates');
   knownKeys(updates, ['enabled'], 'updates');
@@ -294,7 +299,7 @@ const INITIAL_CONFIG_HEADER = [
 ] as const;
 
 export const CONFIG_KEY_ORDER = new Map<string, readonly string[]>([
-  ['', ['server', 'storage', 'ui', 'updates', 'auth', 'notifications', 'crowdsec', 'instances']],
+  ['', ['server', 'storage', 'ui', 'updates', 'auth', 'notifications', 'audit', 'crowdsec', 'instances']],
   ['server', ['port', 'basePath']],
   ['storage', ['dataDir', 'geonamesDir', 'walEnabled']],
   ['ui', ['timeZone', 'timeFormat', 'readOnly']],
@@ -302,6 +307,7 @@ export const CONFIG_KEY_ORDER = new Map<string, readonly string[]>([
   ['auth', ['enabled', 'sessionSecret', 'totpSecret', 'totpSeed', 'oidc']],
   ['auth.oidc', ['issuerUrl', 'clientId', 'clientSecret', 'scope', 'groupsClaim', 'adminGroups', 'readOnlyGroups', 'unmatchedRole']],
   ['notifications', ['secretKey', 'allowPrivateAddresses', 'debugPayloads']],
+  ['audit', ['enabled', 'logFile']],
   ['crowdsec', ['simulationsEnabled', 'alertFilters', 'sync']],
   ['crowdsec.alertFilters', ['includeOrigins', 'excludeOrigins', 'includeCapi', 'includeOriginEmpty', 'excludeOriginEmpty', 'legacy']],
   ['crowdsec.alertFilters.legacy', ['origins', 'extraScenarios']],
@@ -512,6 +518,10 @@ export function generateApplicationConfig(env: NodeJS.ProcessEnv, config: Runtim
       allowPrivateAddresses: config.notificationAllowPrivateAddresses,
       debugPayloads: config.notificationDebugPayloads,
     },
+    audit: {
+      enabled: config.auditEnabled,
+      ...(config.auditLogFile ? { logFile: config.auditLogFile } : {}),
+    },
     updates: { enabled: config.updateCheckEnabled },
     crowdsec: {
       simulationsEnabled: config.simulationsEnabled,
@@ -563,6 +573,7 @@ const CONFIG_SECTION_ENV = [
   ['CONFIG_UI', ['ui']],
   ['CONFIG_AUTH', ['auth']],
   ['CONFIG_NOTIFICATIONS', ['notifications']],
+  ['CONFIG_AUDIT', ['audit']],
   ['CONFIG_UPDATES', ['updates']],
   ['CONFIG_CROWDSEC', ['crowdsec']],
   ['CONFIG_INSTANCES', ['instances']],
@@ -587,6 +598,8 @@ const CONFIG_VALUE_ENV = [
   ['CONFIG_AUTH_OIDC_UNMATCHED_ROLE', ['auth', 'oidc', 'unmatchedRole']],
   ['CONFIG_NOTIFICATIONS_ALLOW_PRIVATE_ADDRESSES', ['notifications', 'allowPrivateAddresses']],
   ['CONFIG_NOTIFICATIONS_DEBUG_PAYLOADS', ['notifications', 'debugPayloads']],
+  ['CONFIG_AUDIT_ENABLED', ['audit', 'enabled']],
+  ['CONFIG_AUDIT_LOG_FILE', ['audit', 'logFile']],
   ['CONFIG_UPDATES_ENABLED', ['updates', 'enabled']],
   ['CONFIG_CROWDSEC_SIMULATIONS_ENABLED', ['crowdsec', 'simulationsEnabled']],
   ['CONFIG_CROWDSEC_ALERT_FILTERS_INCLUDE_ORIGINS', ['crowdsec', 'alertFilters', 'includeOrigins']],
@@ -1211,6 +1224,7 @@ function initialConfigReference(document: UnknownRecord): UnknownRecord {
   const auth = record(document.auth, 'auth');
   const oidc = record(auth.oidc, 'auth.oidc');
   const notifications = record(document.notifications, 'notifications');
+  const audit = record(document.audit, 'audit');
   const crowdsec = record(document.crowdsec, 'crowdsec');
   const sync = record(crowdsec.sync, 'crowdsec.sync');
   const filters = crowdsec.alertFilters === undefined ? {} : record(crowdsec.alertFilters, 'crowdsec.alertFilters');
@@ -1310,6 +1324,10 @@ function initialConfigReference(document: UnknownRecord): UnknownRecord {
     notifications: {
       secretKey: { file: '/run/secrets/notification_secret_key' },
       ...notifications,
+    },
+    audit: {
+      logFile: '/app/data/audit.log',
+      ...audit,
     },
     crowdsec: {
       ...crowdsec,

--- a/server/config.ts
+++ b/server/config.ts
@@ -94,6 +94,8 @@ export interface RuntimeConfig {
   timeZone: string | null;
   timeFormat: TimeFormat;
   readOnly: boolean;
+  auditEnabled: boolean;
+  auditLogFile?: string;
   dashboardAuth: DashboardAuthConfig;
   instances: CrowdsecInstanceConfig[];
 }
@@ -429,6 +431,8 @@ function createRuntimeConfigFromEnvironment(env: NodeJS.ProcessEnv): RuntimeConf
     timeZone: parseTimeZone(env.TZ),
     timeFormat: parseTimeFormat(resolveRenamedEnv(env, 'TIME_FORMAT', 'CROWDSEC_TIME_FORMAT')),
     readOnly: parseBooleanEnv(env.PERMISSION_READ_ONLY, false),
+    auditEnabled: parseBooleanEnv(env.AUDIT_ENABLED, true),
+    auditLogFile: env.AUDIT_LOG_FILE?.trim() || undefined,
     dashboardAuth: parseDashboardAuthConfig(env),
     instances: [],
   };


### PR DESCRIPTION
Closes #443

We've got a few people who can add and remove bans, and there was no way to tell after the fact who did what. This adds an audit log of user actions.

#### What it does

Every state-changing user action — adding decisions, deleting decisions and alerts (single, bulk, and per-instance), and per-IP cleanup — writes one `[audit]` line to the application log. Each line is a single JSON object:

```
[audit] {"time":"2026-08-17T21:15:59.564Z","user":"load","role":"admin","action":"decision.add","ip":"203.0.113.7","type":"ban","duration":"1h","reason":"manual","instances":["CrowdSec"],"outcome":"success"}
[audit] {"time":"2026-08-17T21:16:19.630Z","user":"load","role":"admin","action":"decision.delete","decision_ids":["1757"],"values":["203.0.113.7"],"outcome":"success"}
```

- Delete requests only carry decision IDs, so the banned IP/range is resolved from the local cache before the rows are removed and logged as `values`.
- Bulk ID/value lists are capped at 100 entries with a `truncated` flag; the requested/deleted counters stay exact.
- Outcomes are `success`, `partial`, or `failure` based on per-instance results.
- Audit logging never breaks the action it describes — write failures are logged and swallowed.

#### Configuration

| Field | Default | Purpose |
| --- | --- | --- |
| `audit.enabled` | `true` | Write audit entries to the application log |
| `audit.logFile` | unset | Also append entries as JSON lines to a file |

Both are wired through the usual config machinery (`CONFIG_AUDIT_ENABLED` / `CONFIG_AUDIT_LOG_FILE` overrides, generated-config comments, `config.example.yaml`, and a README section). When auth is disabled the user is recorded as `disabled-auth`.

#### Testing

- Unit tests for the logger (line format, file output, disabled mode, and both file-failure paths).
- Route-level integration tests through the real HTTP stack, including one with a real authenticated session asserting the username lands in the entry, and config tests for the new settings and their overrides.
- Full verify pipeline is green: server suite (473 tests), client suite (359 tests), coverage gate, typecheck, lint, and build.
- Manually verified against the load-test server: logged in as `load`, added and deleted decisions and alerts, and checked the lines in both the container log and the configured audit file.

#### Limitations

- Only actions performed through the Web UI are audited — anything done directly via cscli or the LAPI isn't visible here.
- Only performed actions are logged (including partial outcomes); requests that fail before anything happens don't produce an entry.
